### PR TITLE
Support unicode URLs

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ var Layer = require('./lib/layer')
 var methods = require('methods')
 var mixin = require('utils-merge')
 var parseUrl = require('parseurl')
+var normalize = require('unorm').nfc
 var Route = require('./lib/route')
 
 /**
@@ -168,7 +169,7 @@ Router.prototype.handle = function handle(req, res, callback) {
   // manage inter-router variables
   var parentParams = req.params
   var parentUrl = req.baseUrl || ''
-  var done = restore(callback, req, 'baseUrl', 'next', 'params')
+  var done = restore(callback, req, 'url', 'baseUrl', 'next', 'params')
 
   // setup next layer
   req.next = next
@@ -180,6 +181,7 @@ Router.prototype.handle = function handle(req, res, callback) {
   }
 
   // setup basic req values
+  req.url = decode(req.url)
   req.baseUrl = parentUrl
   req.originalUrl = req.originalUrl || req.url
 
@@ -721,5 +723,19 @@ function wrap(old, fn) {
     }
 
     fn.apply(this, args)
+  }
+}
+
+/**
+ * Decode and normalize a uri
+ *
+ * @private
+ */
+
+function decode (str) {
+  try {
+    return normalize(decodeURI(str))
+  } catch (e) {
+    return str
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "methods": "~1.1.1",
     "parseurl": "~1.3.0",
     "path-to-regexp": "0.1.3",
+    "unorm": "~1.3.3",
     "utils-merge": "1.0.0"
   },
   "devDependencies": {

--- a/test/router.js
+++ b/test/router.js
@@ -710,6 +710,19 @@ describe('Router', function () {
       })
     })
   })
+
+  describe('unicode', function () {
+    it('should normalize paths', function (done) {
+      var router = new Router()
+      var server = createServer(router)
+
+      router.get('/caf\u00E9', helloWorld)
+
+      request(server)
+        .get(encodeURI('/cafe\u0301'))
+        .expect(200, 'hello, world', done)
+    })
+  })
 })
 
 function helloWorld(req, res) {


### PR DESCRIPTION
From https://github.com/pillarjs/path-to-regexp/issues/42, I implemented it at the framework level. This is mostly for reference since I'm not sure on some behaviour (you probably want to 400 at decode failure?). Either way, I think this would be a really useful addition - especially for Express 5.0. We just need to update the readme and make it clear which normalized string method is used.
