### PR TITLE
Enable ability to exit router

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ exactly as normal with one exception: they may invoke `next('route')`.
 Calling `next('route')` bypasses the remaining middleware and handler for this
 route, passing the request on to the next route.
 
+Route handlers and middleware can use `next('router')` (yes, that's "router" with an "r") to quick exit the current router instance and continue traversing routes of subsequent routers in the stack.
+
 ### router.param(name, param_middleware)
 
 Maps the specified path parameter `name` to a specialized param-capturing middleware.

--- a/index.js
+++ b/index.js
@@ -189,7 +189,7 @@ Router.prototype.handle = function handle(req, res, callback) {
   next()
 
   function next(err) {
-    var layerError = err === 'route'
+    var layerError = err === 'route' || err === 'router'
       ? null
       : err
 
@@ -207,7 +207,7 @@ Router.prototype.handle = function handle(req, res, callback) {
     }
 
     // no more matching layers
-    if (idx >= stack.length) {
+    if (err === 'router' || idx >= stack.length) {
       defer(done, layerError)
       return
     }

--- a/test/router.js
+++ b/test/router.js
@@ -459,6 +459,21 @@ describe('Router', function () {
       .expect(200, 'saw POST /foo', cb)
     })
 
+    it('should exit the router', function (done) {
+      var router = new Router()
+      var server = createServer(router)
+
+      router.use(function (req, res, next) {
+        next('router')
+      })
+
+      router.use(helloWorld)
+
+      request(server)
+      .get('/')
+      .expect(404, done)
+    })
+
     it('should not invoke for blank URLs', function (done) {
       var router = new Router()
       var server = createServer(function hander(req, res, next) {


### PR DESCRIPTION
Closes https://github.com/pillarjs/router/issues/20. A different API should be considered for the 2.0 router (deprecating `next('route')` too), but I need this feature in todays router.
