### PR TITLE
Handle promises in middleware (catch rejections)

### DIFF
--- a/lib/layer.js
+++ b/lib/layer.js
@@ -16,6 +16,20 @@ var pathRegexp = require('path-to-regexp')
 var debug = require('debug')('router:layer')
 
 /**
+ * Normalize the middleware result with promise error handling.
+ */
+
+function normalize (result, next) {
+  if (result && typeof result.then === 'function') {
+    return result.then(null, function (err) {
+      return next(err || new Error('Promise was rejected with a falsy value'))
+    })
+  }
+
+  return result
+}
+
+/**
  * Module variables.
  * @private
  */
@@ -66,9 +80,9 @@ Layer.prototype.handle_error = function handle_error(error, req, res, next) {
   }
 
   try {
-    fn(error, req, res, next)
+    return normalize(fn(error, req, res, next), next)
   } catch (err) {
-    next(err)
+    return next(err)
   }
 }
 
@@ -90,9 +104,9 @@ Layer.prototype.handle_request = function handle(req, res, next) {
   }
 
   try {
-    fn(req, res, next)
+    return normalize(fn(req, res, next), next)
   } catch (err) {
-    next(err)
+    return next(err)
   }
 }
 

--- a/lib/route.js
+++ b/lib/route.js
@@ -106,7 +106,7 @@ Route.prototype.dispatch = function dispatch(req, res, done) {
 
   req.route = this
 
-  next()
+  return next()
 
   function next(err) {
     if (err && err === 'route') {
@@ -133,9 +133,9 @@ Route.prototype.dispatch = function dispatch(req, res, done) {
     }
 
     if (err) {
-      layer.handle_error(err, req, res, next)
+      return layer.handle_error(err, req, res, next)
     } else {
-      layer.handle_request(req, res, next)
+      return layer.handle_request(req, res, next)
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "after": "0.8.1",
+    "bluebird": "3.0.6",
     "finalhandler": "0.4.0",
     "istanbul": "0.4.0",
     "mocha": "2.3.3",

--- a/test/support/utils.js
+++ b/test/support/utils.js
@@ -16,7 +16,7 @@ function createHitHandle(num) {
   var name = 'x-fn-' + String(num)
   return function hit(req, res, next) {
     res.setHeader(name, 'hit')
-    next()
+    return next()
   }
 }
 


### PR DESCRIPTION
I need more time to focus on the problem and backward compatibility and what it all should mean. This is just some code and tests that I wrote in a few hours, but got stuck with upstream propagation of errors because the models conflict. Here's a couple of conclusions from the little test:
1. The simplest thing to support with minimal changes is just rejected promise handling, but I also _want_ the ability to have upstream propagation (a la Koa)
2. The upstream propagation model is conflicting with the current model which is entirely sequential
3. If upstream propagation were to exist, it would probably not be compatible with current error middleware handlers - this might not be bad, but it's probably a drawback

If someone else has tried something similar, please share your own conclusions and whether I should keep moving forward with trying to support upstream propagation of promise errors (currently I have upstream propagation of resolved promises working fine).

Example:

``` js
router.use(async function (req, res, next) {
  try {
    await next()
  } catch (err) {
    renderError(err)
  }
})

router.use(function (req, res, next) {
  return Promise.reject(new Error('boom!'))
})

router.use(function (err, res, res, next) {
  // This should work, but if an error occurs it'll propagate back up before exiting.
})
```

Full support will also restrict the node version, I believe, to `>= 0.12`, unless we want to include a polyfill in the library.

Edit: So the piece I'm stuck most on and trying to resolve the best way to support is any legacy code that does not return (aka breaks the promise chain).

Edit 2: Probably best to drop all this extra attempt at handling upstream and move it to a separate router module. I'm having trouble reconciling how to support both modes at once, probably not (easily) possible.
