### PR TITLE
Add support for named routes

### DIFF
--- a/index.js
+++ b/index.js
@@ -502,12 +502,16 @@ Router.prototype.use = function use(handler) {
  * and middleware to routes.
  *
  * @param {string} path
+ * @param {string} name (optional)
  * @return {Route}
  * @public
  */
 
-Router.prototype.route = function route(path) {
-  var route = new Route(path)
+Router.prototype.route = function route(path, name) {
+  if(arguments.length > 1 && this.findRoute(name) != null) {
+    throw new Error('a route with that name already exists')
+  }
+  var route = new Route(path, name)
 
   var layer = new Layer(path, {
     sensitive: this.caseSensitive,
@@ -523,6 +527,27 @@ Router.prototype.route = function route(path) {
 
   this.stack.push(layer)
   return route
+}
+
+
+/**
+ * Find a Route with the given name
+ *
+ * @param {string} name
+ * @return {Route} or null if the route does not exist
+ * @public
+ */
+
+Router.prototype.findRoute = function findRoute(name) {
+  var index = 0;
+  while (index < this.stack.length) {
+    var layer = this.stack[index++]
+    var route = layer.route
+    if(route.name != undefined && route.name === name) {
+      return route
+    }
+  }
+  return null
 }
 
 // create Router#VERB functions

--- a/lib/route.js
+++ b/lib/route.js
@@ -31,15 +31,17 @@ var slice = Array.prototype.slice
 module.exports = Route
 
 /**
- * Initialize `Route` with the given `path`,
+ * Initialize `Route` with the given `path` and `name`,
  *
  * @param {String} path
+ * @param {String} name (optional)
  * @api private
  */
 
-function Route(path) {
+function Route(path, name) {
   debug('new %s', path)
   this.path = path
+  this.name = name
   this.stack = []
 
   // route handlers for various http methods

--- a/test/route.js
+++ b/test/route.js
@@ -17,6 +17,19 @@ describe('Router', function () {
       assert.equal(route.path, '/foo')
     })
 
+    it('should set the route name iff provided', function () {
+      var router = new Router()
+      var route = router.route('/abc', 'abcRoute')
+      assert.equal(route.path, '/abc')
+      assert.equal(route.name, 'abcRoute')
+      assert.equal(router.findRoute('abcRoute'), route)
+      assert.throws(router.route.bind(router, '/xyz', 'abcRoute'), /a route with that name already exists/)
+
+      var route2 = router.route('/def')
+      assert.equal(router.findRoute('abcRoute'), route)
+      assert.equal(null, router.findRoute(undefined))
+    })
+
     it('should respond to multiple methods', function (done) {
       var cb = after(3, done)
       var router = new Router()


### PR DESCRIPTION
There have been a couple of requests in the Express project for supporting named routes, https://github.com/expressjs/express/issues/2746 and https://github.com/expressjs/express/issues/2739.  This PR enables a name to be used when a route is created via `Router.route`. Routes with names can be looked up via a new method - `Router.findRoute`.  The `name` argument is optional so no existing functionality should be broken.  A test is also included.