### PR TITLE
Make req.route an object saving route and baseUrl

### DIFF
--- a/index.js
+++ b/index.js
@@ -271,7 +271,8 @@ Router.prototype.handle = function handle(req, res, callback) {
 
     // store route for dispatch on change
     if (route) {
-      req.route = route
+      req.route = req.route || { __proto__: route }
+      req.route.baseUrl = req.baseUrl;
     }
 
     // Capture one-time layer values

--- a/lib/route.js
+++ b/lib/route.js
@@ -104,7 +104,8 @@ Route.prototype.dispatch = function dispatch(req, res, done) {
     method = 'get'
   }
 
-  req.route = this
+  req.route = req.route || { __proto__: this }
+  req.route.baseUrl = req.baseUrl;
 
   next()
 

--- a/test/router.js
+++ b/test/router.js
@@ -411,6 +411,23 @@ describe('Router', function () {
           .expect('x-is-route', 'true')
           .expect(200, done)
         })
+
+        it('should have the correct baseUrl', function (done) {
+          var router = new Router()
+          var inner = new Router()
+          var server = createServer(router)
+
+          inner[method]('/bar', function handle(req, res) {
+            res.setHeader('x-route-base', String(req.route.baseUrl === '/foo'))
+            res.end()
+          })
+          router.use('/foo', inner);
+
+          request(server)
+          [method]('/foo/bar')
+          .expect('x-route-base', 'true')
+          .expect(200, done)
+        })
       })
     })
   })


### PR DESCRIPTION
This PR attempts to implement https://github.com/expressjs/express/issues/2883.

----

When using an error handler you have access to `req.route`
which describes the most recently matched route. However,
some other informaiton (like `req.baseUrl`) gets changed
before the error handler runs.

This commit changes `req.route` to an object that also contains
the `req.baseUrl` before it gets changed.

Since the actual `route` object is not scoped to the current
event, this commit instead uses a new object to store the
`baseUrl` but sets the `__proto__` to the `route` object so that
all its properties are also available.

