### PR TITLE
Catches errors from Promises / Async functions

### DIFF
--- a/lib/layer.js
+++ b/lib/layer.js
@@ -66,7 +66,12 @@ Layer.prototype.handle_error = function handle_error(error, req, res, next) {
   }
 
   try {
-    fn(error, req, res, next)
+    var result = fn(error, req, res, next)
+    if (isPromise(result)) {
+      result.then(null, function (error) {
+        next(error || new Error('Promise rejected with: ' + error))
+      })
+    }
   } catch (err) {
     next(err)
   }
@@ -90,7 +95,12 @@ Layer.prototype.handle_request = function handle(req, res, next) {
   }
 
   try {
-    fn(req, res, next)
+    var result = fn(req, res, next)
+    if (isPromise(result)) {
+      result.then(null, function (error) {
+        next(error || new Error('Promise rejected with: ' + error))
+      })
+    }
   } catch (err) {
     next(err)
   }
@@ -172,4 +182,18 @@ function decode_param(val){
 
     throw err
   }
+}
+
+/**
+ * Returns true if the val is a Promise.
+ *
+ * @param {any} val
+ * @return {boolean}
+ * @private
+ */
+
+function isPromise(val) {
+  return val !== null &&
+    typeof val === 'object' &&
+    typeof val.then === 'function'
 }

--- a/test/route.js
+++ b/test/route.js
@@ -327,6 +327,74 @@ describe('Router', function () {
         .get('/foo')
         .expect(500, 'caught: oh, no!', done)
       })
+
+      it('should handle a returned rejected promise', function(done) {
+        // Only run this test in environments where Promise is defined.
+        if (!global.Promise) {
+          return done();
+        }
+
+        var router = new Router()
+        var route = router.route('/foo')
+        var server = createServer(router)
+
+        route.all(function createError(req, res, next) {
+          return new Promise(function () {
+            throw new Error('boom!')
+          })
+        })
+
+        route.all(function handleError(err, req, res, next) {
+          return new Promise(function () {
+            throw new Error('oh, no!')
+          })
+        })
+
+        route.all(function handleError(err, req, res, next) {
+          return new Promise(function () {
+            res.statusCode = 500
+            res.end('caught: ' + err.message)
+          })
+        })
+
+        request(server)
+        .get('/foo')
+        .expect(500, 'caught: oh, no!', done)
+      })
+
+      it('should handle a returned rejected promise with no value', function(done) {
+        // Only run this test in environments where Promise is defined.
+        if (!global.Promise) {
+          return done();
+        }
+
+        var router = new Router()
+        var route = router.route('/foo')
+        var server = createServer(router)
+
+        route.all(function createError(req, res, next) {
+          return new Promise(function (_, reject) {
+            reject()
+          })
+        })
+
+        route.all(function handleError(err, req, res, next) {
+          return new Promise(function (_, reject) {
+            reject()
+          })
+        })
+
+        route.all(function handleError(err, req, res, next) {
+          return new Promise(function () {
+            res.statusCode = 500
+            res.end('caught: ' + err.message)
+          })
+        })
+
+        request(server)
+        .get('/foo')
+        .expect(500, 'caught: Promise rejected with: undefined', done)
+      })
     })
 
     describe('path', function () {


### PR DESCRIPTION
When returning Promises from a route handler either explicitly or implicitly by using Async Functions, default error handling is lost.

``` js
// Error caught and forwarded as expected
app.get('/', (req, res) => {
  throw new Error('Oh crap!')
})

// Error swallowed and lost
app.get('/', async (req, res) => {
  throw new Error('Oh crap!')
})
```

This PR began as https://github.com/expressjs/express/pull/3053, however it was a breaking change and Route/Layer have been moved to `router` for express@5.
