### PR TITLE
Add Router events

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,81 @@ curl http://127.0.0.1:8080/such_path
 > such_path
 ```
 
+## Events
+
+The router emits three events - `handlestart`, `layer`, and `handleend` - as it processes requests.
+
+### 1. `handlestart`
+
+This event is emitted when the router starts to process a request.
+
+Example:
+
+```js
+router.on('handlestart', function (req) {
+  req.id = Math.random().toString(36).slice(2)
+  console.log('HANDLESTART:', req.id)
+})
+```
+
+### 2. `layer`
+
+This event is emitted when a route layer is matched.
+
+Layers are matched till one of them sends a response back to the client.
+
+Example:
+
+```js
+router.on('layer', function (req, layer) {
+  console.log(layer)
+})
+```
+
+### 3. `handleend`
+
+This event is emitted when the router has finished processing a request and sent a response.
+
+Example:
+
+```js
+router.on('handleend', function (req) {
+  console.log('HANDLEEND:', req.id)
+})
+```
+
+Here is a complete example of using router events in an Express 5 app.
+
+```js
+var express = require('express')
+var app = express()
+
+app.use(function (req, res, next) {
+  next()
+})
+
+app.get('/', function (req, res) {
+  res.send('HELLO')
+})
+
+app.router.on('handlestart', function (req) {
+  req.id = Math.random().toString(36).slice(2)
+  console.log('HANDLESTART:', req.id)
+})
+
+app.router.on('layer', function (req, layer) {
+  if (!('layerCounter' in req)) req.layerCounter = 0
+  console.log('LAYER: %s -> %d', req.id, ++req.layerCounter)
+  // console.log(layer) // uncomment this to log the layer
+})
+
+app.router.on('handleend', function (req, router) {
+  console.log('HANDLEEND:', req.id)
+})
+
+app.listen(3000)
+```
+
 ## License
 
 [MIT](LICENSE)


### PR DESCRIPTION
The following events were added:
1. `handlestart` - emitted when the router starts to handle the router stack.
2. `layer` - emitted when a layer is matched by the router. It returns the matched layer.
3. `handleend` - emitted when the router has completed handling the router stack.

This feature should help developers handle requirements as described in https://github.com/expressjs/express/issues/2501, https://github.com/expressjs/express/pull/3100, and similar. 

Example of usage with Express:

```js
app.router.on('handlestart', function () {
  console.log('------- %d -------', Date.now())
})

app.router.on('layer', function (layer) {
  console.log(layer)
})

app.router.on('handleend', function () {
  console.log('------- %d -------', Date.now())
})
```

@dougwilson @danieljuhl @evanshortiss \o/
