### PR TITLE
Remove unused err argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -667,7 +667,7 @@ function restore(fn, obj) {
     vals[i] = obj[props[i]]
   }
 
-  return function(err){
+  return function(){
     // restore vals
     for (var i = 0; i < props.length; i++) {
       obj[props[i]] = vals[i]


### PR DESCRIPTION
restore() function in lib/router/index.js does not use it's err argument at all.

All tests passed. Same as: https://github.com/expressjs/express/pull/3228