### PR TITLE
Handling promises at router layer

### DIFF
--- a/lib/layer.js
+++ b/lib/layer.js
@@ -66,7 +66,9 @@ Layer.prototype.handle_error = function handle_error(error, req, res, next) {
   }
 
   try {
-    fn(error, req, res, next)
+    var result = fn(error, req, res, next)
+
+    handlePromise(result, next)
   } catch (err) {
     next(err)
   }
@@ -90,7 +92,9 @@ Layer.prototype.handle_request = function handle(req, res, next) {
   }
 
   try {
-    fn(req, res, next)
+    var result = fn(req, res, next)
+
+    handlePromise(result, next)
   } catch (err) {
     next(err)
   }
@@ -177,4 +181,27 @@ function decode_param(val){
 
     throw err
   }
+}
+
+function handlePromise(promise, next) {
+  var isPromise = checkPromise(promise)
+
+  if (!isPromise) {
+    return
+  }
+
+  promise.then(null, function (err) {
+    next(err || new Error('Empty promise rejection'))
+  })
+}
+
+/**
+ *  Returns true if val is a promise
+ *
+ * @param {any} val
+ * @return {boolean}
+ * @private
+ */
+function checkPromise(val) {
+  return !!val && (typeof val === 'object' || typeof val === 'function') && typeof val.then === 'function'
 }


### PR DESCRIPTION
This feature will avoid try/catch block in all express controllers with async functions (async/await) or functions that returns a promise