### PR TITLE
Mark 'options' as optional in JSDoc for Router

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+unreleased
+==========
+
+  * Fix JSDoc for `Router` constructor
+
 1.3.2 / 2017-09-24
 ==================
 

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ module.exports.Route = Route
 /**
  * Initialize a new `Router` with the given `options`.
  *
- * @param {object} options
+ * @param {object} [options]
  * @return {Router} which is a callable function
  * @public
  */


### PR DESCRIPTION
The code handles them as optional with a default of '{}', and the README similarly shows the examples without any options argument.