### PR TITLE
Add support for throwing in async handlers.

### DIFF
--- a/lib/layer.js
+++ b/lib/layer.js
@@ -65,6 +65,10 @@ Layer.prototype.handle_error = function handle_error(error, req, res, next) {
     return next(error)
   }
 
+  if (fn.constructor.name === 'AsyncFunction') {
+    return fn(error, req, res, next).catch(next)
+  }
+
   try {
     fn(error, req, res, next)
   } catch (err) {
@@ -87,6 +91,10 @@ Layer.prototype.handle_request = function handle(req, res, next) {
   if (fn.length > 3) {
     // not a standard request handler
     return next()
+  }
+
+  if (fn.constructor.name === 'AsyncFunction') {
+    return fn(req, res, next).catch(next)
   }
 
   try {

--- a/test/support/utils.js
+++ b/test/support/utils.js
@@ -124,7 +124,7 @@ function shouldNotHaveHeader(header) {
 
 function asyncFunctionsSupported() {
   try {
-    new Function([],"return async function(){}");
+    new Function([],"return async function(){}")
     return true
   } catch(e) {
     return false

--- a/test/support/utils.js
+++ b/test/support/utils.js
@@ -12,6 +12,7 @@ exports.rawrequest = rawrequest
 exports.request = request
 exports.shouldHitHandle = shouldHitHandle
 exports.shouldNotHitHandle = shouldNotHitHandle
+exports.asyncFunctionsSupported = asyncFunctionsSupported
 
 function createHitHandle(num) {
   var name = 'x-fn-' + String(num)
@@ -118,5 +119,14 @@ function shouldNotHitHandle(num) {
 function shouldNotHaveHeader(header) {
   return function (res) {
     assert.ok(!(header.toLowerCase() in res.headers), 'should not have header ' + header)
+  }
+}
+
+function asyncFunctionsSupported() {
+  try {
+    new Function([],"return async function(){}");
+    return true
+  } catch(e) {
+    return false
   }
 }


### PR DESCRIPTION
# Add support for throwing in async handlers without `UnhandledPromiseRejectionWarning`

## What
- if a handler or error handler has a constructor name of `AsyncFunction`, it will pass `next` to the handler's `.catch`.

## Why
This gives developers the freedom to throw again but also means they don't have to do the following pattern.

```javascript
async function (req, res, next) {
  let result;
  try {
    result = await something();
  } catch (err) {
    next(err);
  }
  res.send(result);
}
```

They can instead do:
```javascript
async function (req, res, next) {
  res.send(await something());
}
```
