### PR TITLE
Handle 405 status code in case of not allowed method

### DIFF
--- a/index.js
+++ b/index.js
@@ -230,7 +230,7 @@ Router.prototype.handle = function handle(req, res, callback) {
     var match
     var route
     //flag indicating route has same http method as request method
-    var has_method
+    var has_method=true;
 
     while (match !== true && idx < stack.length) {
       layer = stack[idx++]
@@ -268,7 +268,7 @@ Router.prototype.handle = function handle(req, res, callback) {
       }
 
       // don't even bother matching route
-      if (!has_method && method !== 'HEAD') {
+      if (!has_method) {
         match = false
         continue
       }

--- a/index.js
+++ b/index.js
@@ -230,7 +230,7 @@ Router.prototype.handle = function handle(req, res, callback) {
     var match
     var route
     //flag indicating route has same http method as request method
-    var has_method=true;
+    var has_method = true
 
     while (match !== true && idx < stack.length) {
       layer = stack[idx++]
@@ -262,13 +262,13 @@ Router.prototype.handle = function handle(req, res, callback) {
 
       // build up automatic options response
       if (!has_method && method === 'OPTIONS' && methods) {
-        //skip options cause it get all methods supported 
-        has_method=true;
+      //skip options cause it get all methods supported 
+        has_method = true
         methods.push.apply(methods, route._methods())
       }
 
       // don't even bother matching route
-      if (!has_method) {
+      if (!has_method && method !== 'HEAD') {
         match = false
         continue
       }
@@ -276,10 +276,9 @@ Router.prototype.handle = function handle(req, res, callback) {
 
     // no match
     if (match !== true) {
-      
       //In case not matching between request and route methods send 405 not allowed error
       if (!has_method) {
-        layerError = { statusCode: 405, stack: "Method Not Allowed" };
+        layerError = { statusCode: 405, stack: "Method Not Allowed" }
       }
 
       return done(layerError)

--- a/index.js
+++ b/index.js
@@ -262,7 +262,6 @@ Router.prototype.handle = function handle(req, res, callback) {
 
       // build up automatic options response
       if (!has_method && method === 'OPTIONS' && methods) {
-      //skip options cause it get all methods supported 
         has_method = true
         methods.push.apply(methods, route._methods())
       }

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ var slice = Array.prototype.slice
 /* istanbul ignore next */
 var defer = typeof setImmediate === 'function'
   ? setImmediate
-  : function(fn){ process.nextTick(fn.bind.apply(fn, arguments)) }
+  : function (fn) { process.nextTick(fn.bind.apply(fn, arguments)) }
 
 /**
  * Expose `Router`.
@@ -81,7 +81,7 @@ function Router(options) {
  */
 
 /* istanbul ignore next */
-Router.prototype = function () {}
+Router.prototype = function () { }
 
 /**
  * Map the given param placeholder `name`(s) to the given callback.
@@ -229,6 +229,8 @@ Router.prototype.handle = function handle(req, res, callback) {
     var layer
     var match
     var route
+    //flag indicating route has same http method as request method
+    var has_method
 
     while (match !== true && idx < stack.length) {
       layer = stack[idx++]
@@ -256,10 +258,12 @@ Router.prototype.handle = function handle(req, res, callback) {
       }
 
       var method = req.method
-      var has_method = route._handles_method(method)
+      has_method = route._handles_method(method)
 
       // build up automatic options response
       if (!has_method && method === 'OPTIONS' && methods) {
+        //skip options cause it get all methods supported 
+        has_method=true;
         methods.push.apply(methods, route._methods())
       }
 
@@ -272,6 +276,12 @@ Router.prototype.handle = function handle(req, res, callback) {
 
     // no match
     if (match !== true) {
+      
+      //In case not matching between request and route methods send 405 not allowed error
+      if (!has_method) {
+        layerError = { statusCode: 405, stack: "Method Not Allowed" };
+      }
+
       return done(layerError)
     }
 
@@ -369,7 +379,7 @@ Router.prototype.process_params = function process_params(layer, called, req, re
       return done(err)
     }
 
-    if (i >= keys.length ) {
+    if (i >= keys.length) {
       return done()
     }
 
@@ -527,7 +537,7 @@ Router.prototype.route = function route(path) {
 }
 
 // create Router#VERB functions
-methods.concat('all').forEach(function(method){
+methods.concat('all').forEach(function (method) {
   Router.prototype[method] = function (path) {
     var route = this.route(path)
     route[method].apply(route, slice.call(arguments, 1))
@@ -667,7 +677,7 @@ function restore(fn, obj) {
     vals[i] = obj[props[i]]
   }
 
-  return function(){
+  return function () {
     // restore vals
     for (var i = 0; i < props.length; i++) {
       obj[props[i]] = vals[i]

--- a/index.js
+++ b/index.js
@@ -268,7 +268,7 @@ Router.prototype.handle = function handle(req, res, callback) {
       }
 
       // don't even bother matching route
-      if (!has_method && method !== 'HEAD') {
+      if (!has_method) {
         match = false
         continue
       }

--- a/test/route.js
+++ b/test/route.js
@@ -20,6 +20,7 @@ describe('Router', function () {
     })
 
     it('should respond to multiple methods', function (done) {
+
       var cb = after(3, done)
       var router = new Router()
       var route = router.route('/foo')
@@ -38,7 +39,7 @@ describe('Router', function () {
 
       request(server)
       .put('/foo')
-      .expect(404, cb)
+      .expect(405, cb)
     })
 
     it('should stack', function (done) {
@@ -79,11 +80,11 @@ describe('Router', function () {
 
       request(server)
       .get('/foo')
-      .expect(404, cb)
+      .expect(405, cb)
 
       request(server)
       .head('/foo')
-      .expect(404, cb)
+      .expect(405, cb)
     })
 
     it('should not invoke singular error route', function (done) {


### PR DESCRIPTION
According to the issue number [2414](https://github.com/expressjs/express/issues/2414) in express which indicates the issue of sending 405 status code in case of not allowed http method and this issue is found in the router module

To solve it , we Updated Router.prototype.handle to send 405 status code in case of not allowed method for given url

Updates are inside Router.prototype.handle function which are  : 

* moving declaration of <code>has_method</code> variable outside of loop on line number 233
* adding <code>has_method=true</code> on line number 266
* adding if statement on lines 281,282,283