### PR TITLE
add solution for handling 405 response code for wrong http methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -230,8 +230,8 @@ Router.prototype.handle = function handle(req, res, callback) {
     var match
     var route
     // flag indicating route has same http method as request method
-    var has_method = true
-    var routeoptions=[]
+    var hasMethod = true
+    var routeOptions=[]
 
     while (match !== true && idx < stack.length) {
       layer = stack[idx++]
@@ -259,18 +259,18 @@ Router.prototype.handle = function handle(req, res, callback) {
       }
 
       var method = req.method
-      routeoptions = route._methods()
-      has_method = route._handles_method(method)
+      routeOptions = route._methods()
+      hasMethod = route._handles_method(method)
 
 
       // build up automatic options response
-      if (!has_method && method === 'OPTIONS' && methods) {
-        has_method=true
-        methods.push.apply(methods, routeoptions)
+      if (!hasMethod && method === 'OPTIONS' && methods) {
+        hasMethod=true
+        methods.push.apply(methods, routeOptions)
       }
 
       // don't even bother matching route
-      if (!has_method) {
+      if (!hasMethod) {
         match = false
         continue
       }
@@ -279,8 +279,8 @@ Router.prototype.handle = function handle(req, res, callback) {
     // no match
     if (match !== true) {
       // In case not matching between request and route methods send 405 not allowed error
-      if (!has_method && routeoptions.length) {
-        layerError = { statusCode: 405, stack: "Method Not Allowed" }
+      if (!has_method && routeOptions.length) {
+        layerError = { ...layerError, statusCode: 405, stack: "Method Not Allowed" }
       }
 
       return done(layerError)

--- a/index.js
+++ b/index.js
@@ -259,14 +259,14 @@ Router.prototype.handle = function handle(req, res, callback) {
       }
 
       var method = req.method
-      routeOptions = route._methods()
+      var isUseCall = !route._methods().length
       hasMethod = route._handles_method(method)
 
 
       // build up automatic options response
       if (!hasMethod && method === 'OPTIONS' && methods) {
         hasMethod=true
-        methods.push.apply(methods, routeOptions)
+        methods.push.apply(methods, route._methods())
       }
 
       // don't even bother matching route
@@ -279,8 +279,10 @@ Router.prototype.handle = function handle(req, res, callback) {
     // no match
     if (match !== true) {
       // In case not matching between request and route methods send 405 not allowed error
-      if (!has_method && routeOptions.length) {
-        layerError = { ...layerError, statusCode: 405, stack: "Method Not Allowed" }
+      if (!hasMethod && !isUseCall) {
+        layerError=new Error("Method Not Allowed")
+        layerError.statusCode = 405
+        layerError.stack = "Method Not Allowed"
       }
 
       return done(layerError)

--- a/test/route.js
+++ b/test/route.js
@@ -38,7 +38,7 @@ describe('Router', function () {
 
       request(server)
       .put('/foo')
-      .expect(404, cb)
+      .expect(405, cb)
     })
 
     it('should stack', function (done) {
@@ -80,6 +80,10 @@ describe('Router', function () {
       request(server)
       .get('/foo')
       .expect(404, cb)
+
+      request(server)
+        .options('/foo')
+        .expect(404, cb)
 
       request(server)
       .head('/foo')

--- a/test/route.js
+++ b/test/route.js
@@ -41,6 +41,28 @@ describe('Router', function () {
       .expect(405, cb)
     })
 
+    it('should respond with 405 in case not allowed', function (done) {
+      var cb = after(2, done)
+      var router = new Router()
+      var route = router.route('/foo')
+      var server = createServer(router)
+
+      route.get(saw)
+      route.post(saw)
+
+      request(server)
+      .put('/foo')
+      .expect(405, cb)
+
+      router.use(function(req, res, next) {
+        next()
+      })
+
+      request(server)
+      .put('/foo')
+      .expect(405, cb)
+    })
+
     it('should stack', function (done) {
       var cb = after(3, done)
       var router = new Router()


### PR DESCRIPTION
According to the issue number [2414](https://github.com/expressjs/express/issues/2414) in express which indicates sending 405 status code in case of not allowed http method for existing resource  and this issue is found in the router module.

Made an update to handle this issue