### PR TITLE
Update path-to-regexp version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "debug": "2.6.9",
     "methods": "~1.1.2",
     "parseurl": "~1.3.2",
-    "path-to-regexp": "0.1.7",
+    "path-to-regexp": "2.4.0",
     "setprototypeof": "1.1.0",
     "utils-merge": "1.0.1"
   },


### PR DESCRIPTION
I suggest to Update path-to-regexp to latest to solve issue number #[2495](https://github.com/expressjs/express/issues/2495)