### PR TITLE
Treat returned promise like calling next

### DIFF
--- a/lib/layer.js
+++ b/lib/layer.js
@@ -71,7 +71,9 @@ Layer.prototype.handle_error = function handle_error(error, req, res, next) {
 
     // wait for returned promise
     if (isPromise(ret)) {
-      ret.then(null, function (error) {
+      ret.then(function () {
+        next()
+      }, function (error) {
         next(error || new Error('Rejected promise'))
       })
     }
@@ -103,7 +105,9 @@ Layer.prototype.handle_request = function handle(req, res, next) {
 
     // wait for returned promise
     if (isPromise(ret)) {
-      ret.then(null, function (error) {
+      ret.then(function () {
+        next()
+      }, function (error) {
         next(error || new Error('Rejected promise'))
       })
     }


### PR DESCRIPTION
Ok, so I *think* this is the next evolution in promise handling support.  We have error support (#47), but this would make it so a resolved promise returned from a middleware would be like calling next.  For example:

```javascript
app.use(async (req, res) => {
  res.locals.user = await loadUser()
})
```

There was a ton of conversation about making it "koa" like in #32.  And like what was concluded in there, that is a large paradigm shift for this router.  So instead of doing all that in one go, I figured it was better to just start with this smaller part.

I don't know what @blakeembrey thinks, but I think this is the best successor to his PR without going the full distance to handle `await next()` style usage.   Thoughts?