### PR TITLE
test: fix potential timeout

### DIFF
--- a/test/router.js
+++ b/test/router.js
@@ -130,6 +130,8 @@ describe('Router', function () {
     })
 
     it('should not stack overflow with many registered routes', function (done) {
+      this.timeout(5000) // long-running test
+
       var router = new Router()
       var server = createServer(router)
 


### PR DESCRIPTION
The default timeout for one test was too low in case the test was
run from a slow machine. This increases the timeout to 4 seconds.

Refs: https://ci.nodejs.org/view/Node.js-citgm/job/citgm-smoker/1758/nodes=aix61-ppc64/testReport/junit/(root)/citgm/router_v1_3_3/