### PR TITLE
deps: setprototypeof@1.2.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,7 +3,7 @@ unreleased
 
   * deps: array-flatten@2.1.2
   * deps: parseurl@~1.3.3
-  * deps: setprototypeof@1.1.1
+  * deps: setprototypeof@1.2.0
 
 1.3.3 / 2018-07-06
 ==================

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "methods": "~1.1.2",
     "parseurl": "~1.3.3",
     "path-to-regexp": "0.1.7",
-    "setprototypeof": "1.1.1",
+    "setprototypeof": "1.2.0",
     "utils-merge": "1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Doesn't have impact here, but this release includes mitigation for a possible prototype pollution.  I will be opening up a series of these on the Express repos.