### PR TITLE
Handle rejected promises from `router.param`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,8 @@
 
 This incorporates all changes after 1.3.5 up to 1.3.6.
 
+  * Add support for returned, rejected Promises to `router.param`
+
 2.0.0-beta.1 / 2020-03-29
 =========================
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ Maps the specified path parameter `name` to a specialized param-capturing middle
 
 This function positions the middleware in the same stack as `.use`.
 
+The function can optionally return a `Promise` object. If a `Promise` object
+is returned from the function, the router will attach an `onRejected` callback
+using `.then`. If the promise is rejected, `next` will be called with the
+rejected value, or an error if the value is falsy.
+
 Parameter mapping is used to provide pre-conditions to routes
 which use normalized placeholders. For example a _:user_id_ parameter
 could automatically load a user's information from the database without

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@
  */
 
 var flatten = require('array-flatten').flatten
+var isPromise = require('is-promise')
 var Layer = require('./lib/layer')
 var methods = require('methods')
 var mixin = require('utils-merge')
@@ -642,7 +643,12 @@ function processParams (params, layer, called, req, res, done) {
     if (!fn) return param()
 
     try {
-      fn(req, res, paramCallback, paramVal, key.name)
+      var ret = fn(req, res, paramCallback, paramVal, key.name)
+      if (isPromise(ret)) {
+        ret.then(null, function (error) {
+          paramCallback(error || new Error('Rejected promise'))
+        })
+      }
     } catch (e) {
       paramCallback(e)
     }

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -12,6 +12,7 @@
  * @private
  */
 
+var isPromise = require('is-promise')
 var pathRegexp = require('path-to-regexp')
 
 /**
@@ -185,20 +186,6 @@ function decodeParam (val) {
 
     throw err
   }
-}
-
-/**
- * Returns true if the val is a Promise.
- *
- * @param {*} val
- * @return {boolean}
- * @private
- */
-
-function isPromise (val) {
-  return val &&
-    typeof val === 'object' &&
-    typeof val.then === 'function'
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "repository": "pillarjs/router",
   "dependencies": {
     "array-flatten": "3.0.0",
+    "is-promise": "4.0.0",
     "methods": "~1.1.2",
     "parseurl": "~1.3.3",
     "path-to-regexp": "3.2.0",


### PR DESCRIPTION
Closes #91 

Checks if function passed to `router.param` returns a promise, catches rejected promise. 

Ended up reusing the same approach from handling rejected promises from middleware.

Moved the `isPromise` function used for handling middleware promises into a new `util` folder to share the logic without duplicating it. 