### PR TITLE
Use diagnostics_channel in layers

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,6 +164,7 @@ Router.prototype.handle = function handle(req, res, callback) {
   var self = this
   var slashAdded = false
   var paramcalled = {}
+  var matchedLayer = false
 
   // middleware and routes
   var stack = this.stack
@@ -285,6 +286,14 @@ Router.prototype.handle = function handle(req, res, callback) {
       ? mergeParams(layer.params, parentParams)
       : layer.params
     var layerPath = layer.path
+
+    if (!matchedLayer) {
+      matchedLayer = true
+      req.layerStack = req.layerStack || []
+    } else {
+      req.layerStack.pop()
+    }
+    req.layerStack.push(layer)
 
     // this should be done for the layer
     self.process_params(layer, paramcalled, req, res, function (err) {

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -23,8 +23,8 @@ var onHandleRequest
 var onHandleError
 try {
   var dc = require('diagnostics_channel')
-  onHandleRequest = dc.channel('express.layer.handle_request')
-  onHandleError = dc.channel('express.layer.handle_error')
+  onHandleRequest = dc.channel('router.layer.handle_request')
+  onHandleError = dc.channel('router.layer.handle_error')
 } catch (err) { }
 
 /**

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -78,9 +78,6 @@ Layer.prototype.handle_error = function handle_error(error, req, res, next) {
     return next(error)
   }
 
-  req.layerStack = req.layerStack || []
-  req.layerStack.push(this)
-
   if (onHandleError && onHandleError.shouldPublish()) {
     onHandleError.publish({
       error: error,
@@ -92,9 +89,7 @@ Layer.prototype.handle_error = function handle_error(error, req, res, next) {
 
   try {
     fn(error, req, res, next)
-    req.layerStack.pop()
   } catch (err) {
-    req.layerStack.pop()
     next(err)
   }
 }
@@ -116,9 +111,6 @@ Layer.prototype.handle_request = function handle(req, res, next) {
     return next()
   }
 
-  req.layerStack = req.layerStack || []
-  req.layerStack.push(this)
-
   if (onHandleRequest && onHandleRequest.shouldPublish()) {
     onHandleRequest.publish({
       request: req,
@@ -129,9 +121,7 @@ Layer.prototype.handle_request = function handle(req, res, next) {
 
   try {
     fn(req, res, next)
-    req.layerStack.pop()
   } catch (err) {
-    req.layerStack.pop()
     next(err)
   }
 }

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -16,6 +16,18 @@ var pathRegexp = require('path-to-regexp')
 var debug = require('debug')('router:layer')
 
 /**
+ * Diagnostic channels
+ * @private
+ */
+var onHandleRequest
+var onHandleError
+try {
+  var dc = require('diagnostics_channel')
+  onHandleRequest = dc.channel('express.layer.handle_request')
+  onHandleError = dc.channel('express.layer.handle_error')
+} catch (err) { }
+
+/**
  * Module variables.
  * @private
  */
@@ -41,6 +53,7 @@ function Layer(path, options, fn) {
   this.params = undefined
   this.path = undefined
   this.regexp = pathRegexp(path, this.keys = [], opts)
+  this.routingPath = path
 
   // set fast path flags
   this.regexp.fast_star = path === '*'
@@ -65,9 +78,23 @@ Layer.prototype.handle_error = function handle_error(error, req, res, next) {
     return next(error)
   }
 
+  req.layerStack = req.layerStack || []
+  req.layerStack.push(this)
+
+  if (onHandleError && onHandleError.shouldPublish()) {
+    onHandleError.publish({
+      error: error,
+      request: req,
+      response: res,
+      layer: this
+    })
+  }
+
   try {
     fn(error, req, res, next)
+    req.layerStack.pop()
   } catch (err) {
+    req.layerStack.pop()
     next(err)
   }
 }
@@ -89,9 +116,22 @@ Layer.prototype.handle_request = function handle(req, res, next) {
     return next()
   }
 
+  req.layerStack = req.layerStack || []
+  req.layerStack.push(this)
+
+  if (onHandleRequest && onHandleRequest.shouldPublish()) {
+    onHandleRequest.publish({
+      request: req,
+      response: res,
+      layer: this
+    })
+  }
+
   try {
     fn(req, res, next)
+    req.layerStack.pop()
   } catch (err) {
+    req.layerStack.pop()
     next(err)
   }
 }

--- a/lib/route.js
+++ b/lib/route.js
@@ -93,6 +93,7 @@ Route.prototype._methods = function _methods() {
  */
 
 Route.prototype.dispatch = function dispatch(req, res, done) {
+  var matchedLayer = false
   var idx = 0
   var stack = this.stack
   if (stack.length === 0) {
@@ -137,6 +138,14 @@ Route.prototype.dispatch = function dispatch(req, res, done) {
     if (match !== true) {
       return done(err)
     }
+
+    if (!matchedLayer) {
+      matchedLayer = true
+      req.layerStack = req.layerStack || []
+    } else {
+      req.layerStack.pop()
+    }
+    req.layerStack.push(layer)
 
     if (err) {
       layer.handle_error(err, req, res, next)

--- a/test/diagnostics-channel.js
+++ b/test/diagnostics-channel.js
@@ -1,0 +1,104 @@
+
+var Router = require('../')
+  , assert = require('assert');
+
+var dc = require('diagnostics_channel');
+var onHandleRequest = dc.channel('express.layer.handle_request');
+var onHandleError = dc.channel('express.layer.handle_error');
+
+function mapProp(prop) {
+  return function mapped(obj) {
+    return obj[prop];
+  };
+}
+
+function mapAndJoin(prop) {
+  return function (list) {
+    return list.map(mapProp(prop)).join('');
+  }
+}
+
+function noop() { }
+
+describe('diagnostics_channel', function () {
+  var joinLayerStack = mapAndJoin('routingPath');
+  var handleRequest;
+  var handleError;
+
+  onHandleRequest.subscribe(function (message) {
+    handleRequest = message;
+  });
+
+  onHandleError.subscribe(function (message) {
+    handleError = message;
+  });
+
+  it('use has no layers with a path', function (done) {
+    var router = new Router();
+
+    router.use(function (req, res) {
+      res.end();
+    });
+
+    function end() {
+      assert.strictEqual(joinLayerStack(handleRequest.request.layerStack), '/');
+      done();
+    }
+
+    router.handle({ url: '/', method: 'GET' }, { end }, noop);
+  });
+
+  it('regular routes have a layer with a path', function (done) {
+    var router = new Router();
+
+    router.get('/hello/:name', function (req, res) {
+      res.end();
+    });
+
+    function end() {
+      assert.strictEqual(joinLayerStack(handleRequest.request.layerStack), '/hello/:name/');
+      done();
+    }
+
+    router.handle({ url: '/hello/world', method: 'GET' }, { end }, noop);
+  });
+
+  it('nested routes have multiple layers with paths', function (done) {
+    var outer = new Router();
+    var inner = new Router();
+
+    inner.get('/:name', function (req, res) {
+      res.end();
+    });
+
+    outer.use('/hello', inner);
+
+    function end() {
+      assert.strictEqual(joinLayerStack(handleRequest.request.layerStack), '/hello/:name/');
+      done();
+    }
+
+    outer.handle({ url: '/hello/world', method: 'GET' }, { end }, noop);
+  });
+
+  it('errors send through a different channel', function (done) {
+    var router = new Router();
+    var error = new Error('fail');
+
+    router.get('/hello/:name', function (req, res) {
+      throw error;
+    });
+
+    router.use(function (err, req, res, next) {
+      res.end();
+    });
+
+    function end() {
+      assert.strictEqual(joinLayerStack(handleRequest.request.layerStack), '/hello/:name/');
+      assert.strictEqual(handleError.error, error);
+      done();
+    }
+
+    router.handle({ url: '/hello/world', method: 'GET' }, { end }, noop);
+  });
+});

--- a/test/diagnostics-channel.js
+++ b/test/diagnostics-channel.js
@@ -3,8 +3,8 @@ var Router = require('../')
   , assert = require('assert');
 
 var dc = require('diagnostics_channel');
-var onHandleRequest = dc.channel('express.layer.handle_request');
-var onHandleError = dc.channel('express.layer.handle_error');
+var onHandleRequest = dc.channel('router.layer.handle_request');
+var onHandleError = dc.channel('router.layer.handle_error');
 
 function mapProp(prop) {
   return function mapped(obj) {

--- a/test/diagnostics-channel.js
+++ b/test/diagnostics-channel.js
@@ -71,7 +71,9 @@ describe('diagnostics_channel', function () {
       res.end();
     });
 
-    outer.use('/hello', inner);
+    outer.use('/hello', (req, res, next) => {
+      next();
+    }, inner);
 
     function end() {
       assert.strictEqual(joinLayerStack(handleRequest.request.layerStack), '/hello/:name/');


### PR DESCRIPTION
This is a proof-of-concept implementation of the [diagnostics_channel](https://github.com/nodejs/node/pull/34895) feature I'm working on in Node.js core. The value here is for APM products to be able to capture changes to routing state through the lifecycle of a request. This should of course not be merged until the module exists in Node.js itself. I'm just creating this now to prove the value to userland and to make sure a more complex framework can benefit from it.

APM vendors want to use events from `diagnostics_channel` to know when a route has changed and what the full routing path to the route is so they can bucket trace data based on the full routing path. For example, requests to `/hello/world` and `/hello/stephen` might map to a `/:name` route on a nested router under `/hello` which should be able to produce `/hello/:name` as the full routing path. This requires some method of tracking the active layer so the point at which the diagnostics_channel events are published there will be valid routing information present for the subscriber to gather from the request.

I'll leave this as a draft PR until diagnostics_channel lands in Node.js core.