### PR TITLE
deps: path-to-regexp@6.2.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,11 @@
 This incorporates all changes after 1.3.5 up to 1.3.7.
 
   * Add support for returned, rejected Promises to `router.param`
+  * deps: path-to-regexp@6.2.0
+    - Support for **named capturing groups** in paths using `RegExp`, i.e.: `/\/(?<group>.+)/` would result in `req.params.group` being populated.
+    - Custom **prefix and suffix groups** using `{}`, e.g.: `/:entity{-:action}?` would match `/user` and `/user-delete`.
+    - Unbalanced patterns would now produce an error: `/test(foo` previously would worked, now it expects either `(` to be closed or the character to be escaped for the previous behavior, e.g. `/test\\(foo`.
+    - Just like with parentheses since `2.0.0-beta.1`, bracket literals now require escaping, i.e.: `/user{:id}` no longer matches `/user{42}` as before unless written as `/user\\{:id\\}`.
 
 2.0.0-beta.1 / 2020-03-29
 =========================

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,8 +7,8 @@ This incorporates all changes after 1.3.5 up to 1.3.7.
   * deps: path-to-regexp@6.2.0
     - Support for **named capturing groups** in paths using `RegExp`, i.e.: `/\/(?<group>.+)/` would result in `req.params.group` being populated.
     - Custom **prefix and suffix groups** using `{}`, e.g.: `/:entity{-:action}?` would match `/user` and `/user-delete`.
-    - Unbalanced patterns would now produce an error: `/test(foo` previously would worked, now it expects either `(` to be closed or the character to be escaped for the previous behavior, e.g. `/test\\(foo`.
-    - Just like with parentheses since `2.0.0-beta.1`, bracket literals now require escaping, i.e.: `/user{:id}` no longer matches `/user{42}` as before unless written as `/user\\{:id\\}`.
+    - Unbalanced patterns now produce an error: `/test(foo` previously worked, but now it expects `(` to be escaped for the previous behavior, e.g. `/test\\(foo`.
+    - Just like with parentheses since `2.0.0-beta.1`, bracket literals now require escaping, i.e.: `/user{:id}` no longer matches `/user{42}` as before unless written as  `/user\\{:id\\}`.
 
 2.0.0-beta.1 / 2020-03-29
 =========================

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -13,7 +13,7 @@
  */
 
 var isPromise = require('is-promise')
-var pathRegexp = require('path-to-regexp')
+var pathToRegexp = require('path-to-regexp').pathToRegexp
 
 /**
  * Module variables.
@@ -41,7 +41,7 @@ function Layer (path, options, fn) {
   this.name = fn.name || '<anonymous>'
   this.params = undefined
   this.path = undefined
-  this.regexp = pathRegexp((opts.strict ? path : loosen(path)), this.keys, opts)
+  this.regexp = pathToRegexp((opts.strict ? path : loosen(path)), this.keys, opts)
 
   // set fast path flags
   this.regexp._slash = path === '/' && opts.end === false

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "is-promise": "4.0.0",
     "methods": "~1.1.2",
     "parseurl": "~1.3.3",
-    "path-to-regexp": "3.2.0",
+    "path-to-regexp": "6.2.0",
     "setprototypeof": "1.2.0",
     "utils-merge": "1.0.1"
   },

--- a/test/route.js
+++ b/test/route.js
@@ -687,7 +687,7 @@ describe('Router', function () {
             .expect(200, { 0: 's', user: 'tj', op: 'edit' }, cb)
         })
 
-        it('should work inside literal paranthesis', function (done) {
+        it('should work inside literal parenthesis', function (done) {
           var router = new Router()
           var route = router.route('/:user\\(:op\\)')
           var server = createServer(router)
@@ -697,6 +697,27 @@ describe('Router', function () {
           request(server)
             .get('/tj(edit)')
             .expect(200, { user: 'tj', op: 'edit' }, done)
+        })
+
+        it('should allow matching literal parenthesis within a group', function (done) {
+          var cb = after(3, done)
+          var router = new Router()
+          var route = router.route('/:user([a-z\\(\\)]+)')
+          var server = createServer(router)
+
+          route.all(sendParams)
+
+          request(server)
+            .get('/1234')
+            .expect(404, cb)
+
+          request(server)
+            .get('/foo')
+            .expect(200, { user: 'foo' }, cb)
+
+          request(server)
+            .get('/(foo)')
+            .expect(200, { user: '(foo)' }, cb)
         })
 
         it('should work within arrays', function (done) {

--- a/test/route.js
+++ b/test/route.js
@@ -14,6 +14,8 @@ var shouldHitHandle = utils.shouldHitHandle
 var shouldNotHaveBody = utils.shouldNotHaveBody
 var shouldNotHitHandle = utils.shouldNotHitHandle
 
+// Named capturing groups are available from Node `10.0.0` and up
+var describeCaptureGroups = runningOnNodeMajorVersionGreaterOrEqualThan(10) ? describe : describe.skip
 var describePromises = global.Promise ? describe : describe.skip
 
 describe('Router', function () {
@@ -1019,60 +1021,57 @@ describe('Router', function () {
         })
       })
 
-      // Named capturing groups are available from Node `10.0.0` and up
-      if (runningOnNodeMajorVersionGreaterOrEqualThan(10)) {
-        describe('using "(?<name>)"', function () {
-          it('should allow defining capturing groups using regexps', function (done) {
-            var cb = after(3, done)
-            var router = new Router()
-            var route = router.route(/\/(?<name>.+)/)
-            var server = createServer(router)
+      describeCaptureGroups('using "(?<name>)"', function () {
+        it('should allow defining capturing groups using regexps', function (done) {
+          var cb = after(3, done)
+          var router = new Router()
+          var route = router.route(/\/(?<name>.+)/)
+          var server = createServer(router)
 
-            route.all(sendParams)
+          route.all(sendParams)
 
-            request(server)
-              .get('/')
-              .expect(404, cb)
+          request(server)
+            .get('/')
+            .expect(404, cb)
 
-            request(server)
-              .get('/foo/bar')
-              .expect(200, { name: 'foo/bar' }, cb)
+          request(server)
+            .get('/foo/bar')
+            .expect(200, { name: 'foo/bar' }, cb)
 
-            request(server)
-              .get('/foo')
-              .expect(200, { name: 'foo' }, cb)
-          })
-
-          it('should work with multiple named groups in the same segment', function (done) {
-            var cb = after(5, done)
-            var router = new Router()
-            var route = router.route(/\/(?<filename>.*).(?<ext>html|pdf|json)/)
-            var server = createServer(router)
-
-            route.all(sendParams)
-
-            request(server)
-              .get('/foo')
-              .expect(404, cb)
-
-            request(server)
-              .get('/foo.xml')
-              .expect(404, cb)
-
-            request(server)
-              .get('/foo.html')
-              .expect(200, { filename: 'foo', ext: 'html' }, cb)
-
-            request(server)
-              .get('/bar.pdf')
-              .expect(200, { filename: 'bar', ext: 'pdf' }, cb)
-
-            request(server)
-              .get('/baz.json')
-              .expect(200, { filename: 'baz', ext: 'json' }, cb)
-          })
+          request(server)
+            .get('/foo')
+            .expect(200, { name: 'foo' }, cb)
         })
-      }
+
+        it('should work with multiple named groups in the same segment', function (done) {
+          var cb = after(5, done)
+          var router = new Router()
+          var route = router.route(/\/(?<filename>.*).(?<ext>html|pdf|json)/)
+          var server = createServer(router)
+
+          route.all(sendParams)
+
+          request(server)
+            .get('/foo')
+            .expect(404, cb)
+
+          request(server)
+            .get('/foo.xml')
+            .expect(404, cb)
+
+          request(server)
+            .get('/foo.html')
+            .expect(200, { filename: 'foo', ext: 'html' }, cb)
+
+          request(server)
+            .get('/bar.pdf')
+            .expect(200, { filename: 'bar', ext: 'pdf' }, cb)
+
+          request(server)
+            .get('/baz.json')
+            .expect(200, { filename: 'baz', ext: 'json' }, cb)
+        })
+      })
     })
   })
 })

--- a/test/route.js
+++ b/test/route.js
@@ -14,8 +14,7 @@ var shouldHitHandle = utils.shouldHitHandle
 var shouldNotHaveBody = utils.shouldNotHaveBody
 var shouldNotHitHandle = utils.shouldNotHitHandle
 
-// Named capturing groups are available from Node `10.0.0` and up
-var describeCaptureGroups = runningOnNodeMajorVersionGreaterOrEqualThan(10) ? describe : describe.skip
+var describeNamedCaptureGroups = supportsRegExp('(?<foo>.)') ? describe : describe.skip
 var describePromises = global.Promise ? describe : describe.skip
 
 describe('Router', function () {
@@ -1021,7 +1020,7 @@ describe('Router', function () {
         })
       })
 
-      describeCaptureGroups('using "(?<name>)"', function () {
+      describeNamedCaptureGroups('using "(?<name>)"', function () {
         it('should allow defining capturing groups using regexps', function (done) {
           var cb = after(3, done)
           var router = new Router()
@@ -1095,6 +1094,10 @@ function sendParams (req, res) {
   res.end(JSON.stringify(req.params))
 }
 
-function runningOnNodeMajorVersionGreaterOrEqualThan (version) {
-  return Number(process.versions.node.split('.')[0]) >= Number(version)
+function supportsRegExp (source) {
+  try {
+    return RegExp(source).source !== ''
+  } catch (e) {
+    return false
+  }
 }


### PR DESCRIPTION
* Bump `path-to-regexp` to `6.2.0`.
* Add tests for new features introduced since `path-to-regexp@3.2.0`.
* Fix minor typos in test descriptions and some `.md` files.