### PR TITLE
'continue' is unnecessary as the last statement in while loop

### DIFF
--- a/index.js
+++ b/index.js
@@ -272,7 +272,6 @@ Router.prototype.handle = function handle(req, res, callback) {
       // don't even bother matching route
       if (!has_method && method !== 'HEAD') {
         match = false
-        continue
       }
     }
 


### PR DESCRIPTION
'continue' is unnecessary as the last statement in while loop inside next() method