### PR TITLE
chore: does master build?

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,3 +391,5 @@ server.listen(8080)
 [coveralls-url]: https://coveralls.io/r/pillarjs/router?branch=master
 [downloads-image]: https://img.shields.io/npm/dm/router.svg
 [downloads-url]: https://npmjs.org/package/router
+
+.


### PR DESCRIPTION
I'm getting in node@4.9.0 on master locally, and a similar failure on [PR-110](https://github.com/pillarjs/router/pull/110).

```
npm ERR! ENOTDIR: not a directory, open '*/router/node_modules/eslint-plugin-markdown/node_modules/mdast-util-from-markdown/node_modules/@types/mdast/package.json'
```

Adding this PR as a test as a check if `master` builds correctly. 

---

Edit: This on a clean environment with `rm -rf node_modules` and `npm cache clean`


