### PR TITLE
Fix spelling error in test name

### DIFF
--- a/test/route.js
+++ b/test/route.js
@@ -574,7 +574,7 @@ describe('Router', function () {
             .expect(200, {'0': 's', 'user': 'tj', 'op': 'edit'}, cb)
         })
 
-        it('should work inside literal paranthesis', function (done) {
+        it('should work inside literal parentheses', function (done) {
           var router = new Router()
           var route = router.route('/:user\\(:op\\)')
           var server = createServer(router)


### PR DESCRIPTION
Just noticed this skimming through the tests and figured I'd offer a quick fix.