### PR TITLE
[Security] Don't store request specific data into the Layer object

### DIFF
--- a/lib/layer.js
+++ b/lib/layer.js
@@ -38,8 +38,6 @@ function Layer(path, options, fn) {
 
   this.handle = fn
   this.name = fn.name || '<anonymous>'
-  this.params = undefined
-  this.path = undefined
   this.regexp = pathRegexp(path, this.keys = [], opts)
 
   // set fast path flags
@@ -111,16 +109,18 @@ Layer.prototype.match = function match(path) {
   if (path != null) {
     // fast path non-ending match for / (any path matches)
     if (this.regexp.fast_slash) {
-      this.params = {}
-      this.path = ''
-      return true
+      return {
+        path: '',
+        params: {}
+      }
     }
 
     // fast path for * (everything matched in a param)
     if (this.regexp.fast_star) {
-      this.params = {'0': decode_param(path)}
-      this.path = path
-      return true
+      return {
+        path: path,
+        params: {'0': decode_param(path)}
+      }
     }
 
     // match the path
@@ -128,18 +128,12 @@ Layer.prototype.match = function match(path) {
   }
 
   if (!match) {
-    this.params = undefined
-    this.path = undefined
     return false
   }
 
-  // store values
-  this.params = {}
-  this.path = match[0]
-
   // iterate matches
   var keys = this.keys
-  var params = this.params
+  var params = {}
 
   for (var i = 1; i < match.length; i++) {
     var key = keys[i - 1]
@@ -151,7 +145,10 @@ Layer.prototype.match = function match(path) {
     }
   }
 
-  return true
+  return {
+    path: match[0],
+    params: params
+  }
 }
 
 /**

--- a/test/req.params.js
+++ b/test/req.params.js
@@ -3,6 +3,7 @@ var Router = require('..')
 var utils = require('./support/utils')
 
 var createServer = utils.createServer
+var assert = utils.assert
 var request = utils.request
 
 describe('req.params', function () {
@@ -65,6 +66,27 @@ describe('req.params', function () {
       .get('/')
       .expect('x-params-1', '{}')
       .expect(200, '{"foo":"bar"}', done)
+  })
+
+  it('should not keep parameters in memory', function (done) {
+    var router = Router()
+    var server = createServer(function (req, res, next) {
+      router(req, res, function (err) {
+        if (err) return next(err)
+        sawParams(req, res)
+      })
+    })
+
+    router.get('/:fizz', hitParams(1))
+
+    request(server)
+      .get('/buzz')
+      .end(function(err) {
+        if (err) return done(err)
+
+        assert.strictEqual(router.stack[0].params, undefined)
+        done()
+      })
   })
 
   describe('when "mergeParams: true"', function () {


### PR DESCRIPTION
### Issue
Currently, the path & params of the latest request is stored into the last matched layer.
The "Layer" object should be immutable: a request should not modify its attributes.

This means that secret parameters are kept into memory after the end a request.
This makes it easier for attacks based on memory access to retrieve sensible data.

### Fix
This PR simply removes the `path` & `params` parameters of the `Layer` object, and return them as the result of the `match` function.

### Test case
A test case is included, to check that the `params` attribute is not available anymore in the Layer.

### History
An initial PR was made on the express project: https://github.com/expressjs/express/pull/5426

### Example
For example, this code will show the latest value of the secret parameter, as the value is stored until a new request is made:
```javascript
const express = require('./index.js');
const app = express();
const port = 3000;

app.get('/secret/:token', (req, res) => {
	res.send('Hello World!');
});

app.listen(port, () => {
	console.log(`Example app listening on port ${port}`);
});

setInterval(() => {
	console.log(app._router.stack.at(2).params);
}, 1000);
```

```bash
curl localhost:3000/secret/super_secret
```

Result:
```
Example app listening on port 3000
undefined
undefined
undefined
{ token: 'super_secret' }
{ token: 'super_secret' }

```