### PR TITLE
build: enable ci workflow trigger and fix ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,18 @@
 name: ci
 
 on:
-- pull_request
-- push
+  workflow_dispatch:
+  push:
+    branches:
+    - main
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         name:
         - Node.js 0.8
@@ -77,11 +82,11 @@ jobs:
 
         - name: Node.js 8.x
           node-version: "8.17"
-          npm-i: mocha@7.2.0
+          npm-i: mocha@7.2.0 nyc@14.1.1
 
         - name: Node.js 9.x
           node-version: "9.11"
-          npm-i: mocha@7.2.0
+          npm-i: mocha@7.2.0 nyc@14.1.1
 
         - name: Node.js 10.x
           node-version: "10.24"


### PR DESCRIPTION
Enables `workflow_dispatch` which allows manually running ci. I am adding this because I am trying to figure out the status of the repo's `master` branch which seems like it should be broken. This is generally a useful feature though so I am going to just merge this and keep it there for now.

Also fixes the nyc issues in node 8/9.