### PR TITLE
Remove Object.setPrototypeOf polyfill

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+unreleased
+==================
+
+* Remove `Object.setPrototypeOf` polyfill
+
 2.0.0 / 2024-09-09
 ==================
 

--- a/index.js
+++ b/index.js
@@ -19,7 +19,6 @@ const methods = require('methods')
 const mixin = require('utils-merge')
 const parseUrl = require('parseurl')
 const Route = require('./lib/route')
-const setPrototypeOf = require('setprototypeof')
 
 /**
  * Module variables.
@@ -60,7 +59,7 @@ function Router (options) {
   }
 
   // inherit from the correct prototype
-  setPrototypeOf(router, this)
+  Object.setPrototypeOf(router, this)
 
   router.caseSensitive = opts.caseSensitive
   router.mergeParams = opts.mergeParams

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "methods": "~1.1.2",
     "parseurl": "~1.3.3",
     "path-to-regexp": "^8.0.0",
-    "setprototypeof": "1.2.0",
     "utils-merge": "1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR removes the `Object.setPrototypeOf` polyfill, which is no longer needed since this package now requires Node.js v18 as the minimum supported version. All existing tests should pass, as this change only impacts older Node versions no longer supported.