### PR TITLE
Use `Array.flat` instead of `array-flatten` package

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+unreleased
+=================
+
+* Use `Array.flat` instead of `array-flatten` package
+
 2.0.0 / 2024-09-09
 ==================
 

--- a/index.js
+++ b/index.js
@@ -12,7 +12,6 @@
  * @private
  */
 
-const flatten = require('array-flatten').flatten
 const isPromise = require('is-promise')
 const Layer = require('./lib/layer')
 const methods = require('methods')
@@ -27,6 +26,7 @@ const setPrototypeOf = require('setprototypeof')
  */
 
 const slice = Array.prototype.slice
+const flatten = Array.prototype.flat
 
 /**
  * Expose `Router`.
@@ -374,7 +374,7 @@ Router.prototype.use = function use (handler) {
     }
   }
 
-  const callbacks = flatten(slice.call(arguments, offset))
+  const callbacks = flatten.call(slice.call(arguments, offset), Infinity)
 
   if (callbacks.length === 0) {
     throw new TypeError('argument handler is required')

--- a/lib/route.js
+++ b/lib/route.js
@@ -12,7 +12,6 @@
  * @private
  */
 
-const flatten = require('array-flatten').flatten
 const Layer = require('./layer')
 const methods = require('methods')
 
@@ -22,6 +21,7 @@ const methods = require('methods')
  */
 
 const slice = Array.prototype.slice
+const flatten = Array.prototype.flat
 
 /* istanbul ignore next */
 const defer = typeof setImmediate === 'function'
@@ -192,7 +192,7 @@ Route.prototype.dispatch = function dispatch (req, res, done) {
  */
 
 Route.prototype.all = function all (handler) {
-  const callbacks = flatten(slice.call(arguments))
+  const callbacks = flatten.call(slice.call(arguments), Infinity)
 
   if (callbacks.length === 0) {
     throw new TypeError('argument handler is required')
@@ -217,7 +217,7 @@ Route.prototype.all = function all (handler) {
 
 methods.forEach(function (method) {
   Route.prototype[method] = function (handler) {
-    const callbacks = flatten(slice.call(arguments))
+    const callbacks = flatten.call(slice.call(arguments), Infinity)
 
     if (callbacks.length === 0) {
       throw new TypeError('argument handler is required')

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "license": "MIT",
   "repository": "pillarjs/router",
   "dependencies": {
-    "array-flatten": "3.0.0",
     "is-promise": "4.0.0",
     "methods": "~1.1.2",
     "parseurl": "~1.3.3",


### PR DESCRIPTION
Since the mimimum supported Node version is v18 the native `Array.flat` method should be used instead of the `array-flatten` package.