### PR TITLE
refactor: replace `methods` dependency with standard library

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@ unreleased
 
 * Remove `Object.setPrototypeOf` polyfill
 * Use `Array.flat` instead of `array-flatten` package
+* Replace `methods` dependency with standard library
 
 2.0.0 / 2024-09-09
 ==================

--- a/lib/route.js
+++ b/lib/route.js
@@ -13,7 +13,7 @@
  */
 
 const Layer = require('./layer')
-const methods = require('methods')
+const { METHODS } = require('node:http')
 
 /**
  * Module variables.
@@ -214,6 +214,9 @@ Route.prototype.all = function all (handler) {
 
   return this
 }
+
+
+const methods = METHODS.map((method) => method.toLowerCase())
 
 methods.forEach(function (method) {
   Route.prototype[method] = function (handler) {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "repository": "pillarjs/router",
   "dependencies": {
     "is-promise": "4.0.0",
-    "methods": "~1.1.2",
     "parseurl": "~1.3.3",
     "path-to-regexp": "^8.0.0",
     "utils-merge": "1.0.1"


### PR DESCRIPTION
Replaces the [`methods`](https://github.com/jshttp/methods/tree/master) dependency with calls to the standard library of Node.js. Since `methods` is mostly a polyfill for `require('node:http').METHODS` in older versions of Node.js that are no longer supported this can be removed.