### PR TITLE
fix: replace `methods` imports everywhere

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@
 
 const isPromise = require('is-promise')
 const Layer = require('./lib/layer')
-const methods = require('methods')
+const { METHODS } = require('node:http')
 const mixin = require('utils-merge')
 const parseUrl = require('parseurl')
 const Route = require('./lib/route')
@@ -26,6 +26,7 @@ const Route = require('./lib/route')
 
 const slice = Array.prototype.slice
 const flatten = Array.prototype.flat
+const methods = METHODS.map((method) => method.toLowerCase())
 
 /**
  * Expose `Router`.

--- a/lib/route.js
+++ b/lib/route.js
@@ -22,6 +22,7 @@ const { METHODS } = require('node:http')
 
 const slice = Array.prototype.slice
 const flatten = Array.prototype.flat
+const methods = METHODS.map((method) => method.toLowerCase())
 
 /* istanbul ignore next */
 const defer = typeof setImmediate === 'function'
@@ -214,9 +215,6 @@ Route.prototype.all = function all (handler) {
 
   return this
 }
-
-
-const methods = METHODS.map((method) => method.toLowerCase())
 
 methods.forEach(function (method) {
   Route.prototype[method] = function (handler) {

--- a/test/route.js
+++ b/test/route.js
@@ -1,6 +1,5 @@
 const { it, describe } = require('mocha')
 const Buffer = require('safe-buffer').Buffer
-const methods = require('methods')
 const series = require('run-series')
 const Router = require('..')
 const utils = require('./support/utils')
@@ -13,6 +12,7 @@ const shouldHaveBody = utils.shouldHaveBody
 const shouldHitHandle = utils.shouldHitHandle
 const shouldNotHaveBody = utils.shouldNotHaveBody
 const shouldNotHitHandle = utils.shouldNotHitHandle
+const methods = utils.methods
 
 const describePromises = global.Promise ? describe : describe.skip
 

--- a/test/router.js
+++ b/test/router.js
@@ -1,7 +1,6 @@
 const { it, describe } = require('mocha')
 const series = require('run-series')
 const Buffer = require('safe-buffer').Buffer
-const methods = require('methods')
 const Router = require('..')
 const utils = require('./support/utils')
 
@@ -14,6 +13,7 @@ const shouldHaveBody = utils.shouldHaveBody
 const shouldHitHandle = utils.shouldHitHandle
 const shouldNotHaveBody = utils.shouldNotHaveBody
 const shouldNotHitHandle = utils.shouldNotHitHandle
+const methods = utils.methods
 
 const describePromises = global.Promise ? describe : describe.skip
 

--- a/test/support/utils.js
+++ b/test/support/utils.js
@@ -2,8 +2,10 @@ const assert = require('assert')
 const Buffer = require('safe-buffer').Buffer
 const finalhandler = require('finalhandler')
 const http = require('http')
-const methods = require('methods')
+const { METHODS } = require('node:http')
 const request = require('supertest')
+
+const methods = METHODS.map((method) => method.toLowerCase())
 
 exports.assert = assert
 exports.createHitHandle = createHitHandle
@@ -14,6 +16,7 @@ exports.shouldHaveBody = shouldHaveBody
 exports.shouldNotHaveBody = shouldNotHaveBody
 exports.shouldHitHandle = shouldHitHandle
 exports.shouldNotHitHandle = shouldNotHitHandle
+exports.methods = methods
 
 function createHitHandle (num) {
   const name = 'x-fn-' + String(num)


### PR DESCRIPTION
I was being sloppy and forgot to remove the import to the `methods` module everywhere under #127. Since it was being included as a transitive dependency the CI passed without issue (thanks NPM).