### PR TITLE
refactor!: replace `is-promise` dependency with `instanceof` check

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,7 @@ unreleased
 * Remove `Object.setPrototypeOf` polyfill
 * Use `Array.flat` instead of `array-flatten` package
 * Replace `methods` dependency with standard library
+* Replace `is-promise` dependency with `instanceof` check (drops support for non-native promises)
 
 2.0.0 / 2024-09-09
 ==================

--- a/index.js
+++ b/index.js
@@ -12,7 +12,6 @@
  * @private
  */
 
-const isPromise = require('is-promise')
 const Layer = require('./lib/layer')
 const methods = require('methods')
 const mixin = require('utils-merge')
@@ -639,7 +638,7 @@ function processParams (params, layer, called, req, res, done) {
 
     try {
       const ret = fn(req, res, paramCallback, paramVal, key)
-      if (isPromise(ret)) {
+      if (ret instanceof Promise) {
         ret.then(null, function (error) {
           paramCallback(error || new Error('Rejected promise'))
         })

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -12,7 +12,6 @@
  * @private
  */
 
-const isPromise = require('is-promise')
 const pathRegexp = require('path-to-regexp')
 
 /**
@@ -113,7 +112,7 @@ Layer.prototype.handleError = function handleError (error, req, res, next) {
     const ret = fn(error, req, res, next)
 
     // wait for returned promise
-    if (isPromise(ret)) {
+    if (ret instanceof Promise) {
       ret.then(null, function (error) {
         next(error || new Error('Rejected promise'))
       })
@@ -145,7 +144,7 @@ Layer.prototype.handleRequest = function handleRequest (req, res, next) {
     const ret = fn(req, res, next)
 
     // wait for returned promise
-    if (isPromise(ret)) {
+    if (ret instanceof Promise) {
       ret.then(null, function (error) {
         next(error || new Error('Rejected promise'))
       })

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "license": "MIT",
   "repository": "pillarjs/router",
   "dependencies": {
-    "is-promise": "4.0.0",
     "parseurl": "~1.3.3",
     "path-to-regexp": "^8.0.0",
     "utils-merge": "1.0.1"


### PR DESCRIPTION
Replaces the `is-promise` dependency with an `instanceof Promise` check.

BREAKING: drops support for non-native promises

Closes #136