### PR TITLE
chore: replace `utils-merge` dependency with `Object.assign()`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,7 @@ unreleased
 * Use `Array.flat` instead of `array-flatten` package
 * Replace `methods` dependency with standard library
 * deps: parseurl@^1.3.3
+* Replace `utils-merge` dependency with `Object.assign`
 
 2.0.0 / 2024-09-09
 ==================

--- a/index.js
+++ b/index.js
@@ -15,7 +15,6 @@
 const isPromise = require('is-promise')
 const Layer = require('./lib/layer')
 const { METHODS } = require('node:http')
-const mixin = require('utils-merge')
 const parseUrl = require('parseurl')
 const Route = require('./lib/route')
 
@@ -527,11 +526,11 @@ function mergeParams (params, parent) {
   }
 
   // make copy of parent for base
-  const obj = mixin({}, parent)
+  const obj = Object.assign({}, parent)
 
   // simple non-numeric merging
   if (!(0 in params) || !(0 in parent)) {
-    return mixin(obj, params)
+    return Object.assign(obj, params)
   }
 
   let i = 0
@@ -557,7 +556,7 @@ function mergeParams (params, parent) {
     }
   }
 
-  return mixin(obj, params)
+  return Object.assign(obj, params)
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   "dependencies": {
     "is-promise": "4.0.0",
     "parseurl": "^1.3.3",
-    "path-to-regexp": "^8.0.0",
-    "utils-merge": "1.0.1"
+    "path-to-regexp": "^8.0.0"
   },
   "devDependencies": {
     "after": "0.8.2",


### PR DESCRIPTION
Replaces the `utils-merge` dependency with the built-in [`Object.assign()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign) method.