### PR TITLE
Release: 2.1.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
-unreleased
+2.1.0 / 2025-02-10
 ==================
 
+* Updated `engines` field to Node@18 or higher
 * Remove `Object.setPrototypeOf` polyfill
 * Use `Array.flat` instead of `array-flatten` package
 * Replace `methods` dependency with standard library

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "router",
   "description": "Simple middleware-style router",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": "Douglas Christopher Wilson <doug@somethingdoug.com>",
   "contributors": [
     "Blake Embrey <hello@blakeembrey.com>"


### PR DESCRIPTION
**Plan to release it on Nov 06**

### What's included in the `HISTORY.md`

* Updated `engines` field to Node@18 or higher
* Remove `Object.setPrototypeOf` polyfill
* Use `Array.flat` instead of `array-flatten` package
* Replace `methods` dependency with standard library

### What's Changed
* Use `Array.flat` instead of `array-flatten` package by @Phillip9587 in https://github.com/pillarjs/router/pull/126
* Remove Object.setPrototypeOf polyfill by @Phillip9587 in https://github.com/pillarjs/router/pull/125
* refactor: replace `methods` dependency with standard library by @jonkoops in https://github.com/pillarjs/router/pull/127
* fix: replace `methods` imports everywhere by @jonkoops in https://github.com/pillarjs/router/pull/130
* fix engines field for 2.0.0 by @ctcpip in https://github.com/pillarjs/router/pull/131
* deps: ispromise@^4.0.0 by @raiandexter0607 in https://github.com/pillarjs/router/pull/135

### New Contributors
* @Phillip9587 made their first contribution in https://github.com/pillarjs/router/pull/126
* @jonkoops made their first contribution in https://github.com/pillarjs/router/pull/127
* @ctcpip made their first contribution in https://github.com/pillarjs/router/pull/131
* @raiandexter0607 made their first contribution in https://github.com/pillarjs/router/pull/135

**Full Changelog**: https://github.com/pillarjs/router/compare/v2.0.0...master