### PR TITLE
cleanup: remove devDependency `safe-buffer`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "mocha": "10.2.0",
     "nyc": "15.1.0",
     "run-series": "^1.1.9",
-    "safe-buffer": "5.2.1",
     "standard": "^17.1.0",
     "supertest": "6.3.3"
   },

--- a/test/route.js
+++ b/test/route.js
@@ -1,5 +1,4 @@
 const { it, describe } = require('mocha')
-const Buffer = require('safe-buffer').Buffer
 const series = require('run-series')
 const Router = require('..')
 const utils = require('./support/utils')

--- a/test/router.js
+++ b/test/router.js
@@ -1,6 +1,5 @@
 const { it, describe } = require('mocha')
 const series = require('run-series')
-const Buffer = require('safe-buffer').Buffer
 const Router = require('..')
 const utils = require('./support/utils')
 

--- a/test/support/utils.js
+++ b/test/support/utils.js
@@ -1,5 +1,4 @@
 const assert = require('assert')
-const Buffer = require('safe-buffer').Buffer
 const finalhandler = require('finalhandler')
 const http = require('http')
 const { METHODS } = require('node:http')


### PR DESCRIPTION
This PR removes the `safe-buffer` package from `devDependencies` as it's no longer needed. Since we no longer support Node.js versions older than 18.0.0, the native Buffer class now fully handles security concerns. Additionally, there are no instances of `new Buffer(...)` usage in the repository.