### PR TITLE
cleanup: remove promise support check from tests

### DIFF
--- a/test/param.js
+++ b/test/param.js
@@ -10,8 +10,6 @@ const shouldNotHitHandle = utils.shouldNotHitHandle
 const createServer = utils.createServer
 const request = utils.request
 
-const describePromises = global.Promise ? describe : describe.skip
-
 describe('Router', function () {
   describe('.param(name, fn)', function () {
     it('should reject missing name', function () {
@@ -264,7 +262,7 @@ describe('Router', function () {
         .expect(500, /Error: boom/, done)
     })
 
-    describePromises('promise support', function () {
+    describe('promise support', function () {
       it('should pass rejected promise value', function (done) {
         const router = new Router()
         const server = createServer(router)

--- a/test/route.js
+++ b/test/route.js
@@ -14,8 +14,6 @@ const shouldNotHaveBody = utils.shouldNotHaveBody
 const shouldNotHitHandle = utils.shouldNotHitHandle
 const methods = utils.methods
 
-const describePromises = global.Promise ? describe : describe.skip
-
 describe('Router', function () {
   describe('.route(path)', function () {
     it('should return a new route', function () {
@@ -542,7 +540,7 @@ describe('Router', function () {
       })
     })
 
-    describePromises('promise support', function () {
+    describe('promise support', function () {
       it('should pass rejected promise value', function (done) {
         const router = new Router()
         const route = router.route('/foo')

--- a/test/router.js
+++ b/test/router.js
@@ -15,8 +15,6 @@ const shouldNotHaveBody = utils.shouldNotHaveBody
 const shouldNotHitHandle = utils.shouldNotHitHandle
 const methods = utils.methods
 
-const describePromises = global.Promise ? describe : describe.skip
-
 describe('Router', function () {
   it('should return a function', function () {
     assert.equal(typeof Router(), 'function')
@@ -770,7 +768,7 @@ describe('Router', function () {
       })
     })
 
-    describePromises('promise support', function () {
+    describe('promise support', function () {
       it('should pass rejected promise value', function (done) {
         const router = new Router()
         const server = createServer(router)


### PR DESCRIPTION
Promises are supported in all supported Node.js version so the check is unnecessary