### PR TITLE
chore: bump path-to-regexp dependency to 0.1.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "debug": "2.6.9",
     "methods": "~1.1.2",
     "parseurl": "~1.3.3",
-    "path-to-regexp": "0.1.7",
+    "path-to-regexp": "0.1.10",
     "setprototypeof": "1.2.0",
     "utils-merge": "1.0.1"
   },


### PR DESCRIPTION
The current version of path-to-regexp has a [CVE](https://github.com/advisories/GHSA-9wv6-86v2-598j) open and causes audit warnings in downstream consumers of this package.

Upgrade to v0.10.0 as recommended in the advisory.

Tested on node v18.20.5.