### PR TITLE
chore: bump path-to-regexp dependency to 0.1.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "debug": "2.6.9",
     "methods": "~1.1.2",
     "parseurl": "~1.3.3",
-    "path-to-regexp": "0.1.7",
+    "path-to-regexp": "0.1.11",
     "setprototypeof": "1.2.0",
     "utils-merge": "1.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "debug": "2.6.9",
     "methods": "~1.1.2",
     "parseurl": "~1.3.3",
-    "path-to-regexp": "0.1.11",
+    "path-to-regexp": "0.1.12",
     "setprototypeof": "1.2.0",
     "utils-merge": "1.0.1"
   },


### PR DESCRIPTION
Although this version of the router is not used for Express, it would be good to update it and release a patch.

same #147 