### PR TITLE
fix: restore 'debug' logs

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+unreleased
+==================
+
+* Restore `debug` dependency
+
 2.1.0 / 2025-02-10
 ==================
 

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ const Layer = require('./lib/layer')
 const { METHODS } = require('node:http')
 const parseUrl = require('parseurl')
 const Route = require('./lib/route')
+const debug = require('debug')('router')
 
 /**
  * Module variables.
@@ -148,6 +149,8 @@ Router.prototype.handle = function handle (req, res, callback) {
   if (!callback) {
     throw new TypeError('argument callback is required')
   }
+
+  debug('dispatching %s %s', req.method, req.url)
 
   let idx = 0
   let methods
@@ -315,6 +318,7 @@ Router.prototype.handle = function handle (req, res, callback) {
 
       // Trim off the part of the url that matches the route
       // middleware (.use stuff) needs to have the path stripped
+      debug('trim prefix (%s) from url %s', layerPath, req.url)
       removed = layerPath
       req.url = protohost + req.url.slice(protohost.length + removed.length)
 
@@ -329,6 +333,8 @@ Router.prototype.handle = function handle (req, res, callback) {
         ? removed.substring(0, removed.length - 1)
         : removed)
     }
+
+    debug('%s %s : %s', layer.name, layerPath, req.originalUrl)
 
     if (layerError) {
       layer.handleError(layerError, req, res, next)
@@ -387,6 +393,8 @@ Router.prototype.use = function use (handler) {
     }
 
     // add the middleware
+    debug('use %o %s', path, fn.name || '<anonymous>')
+
     const layer = new Layer(path, {
       sensitive: this.caseSensitive,
       strict: false,

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -14,6 +14,7 @@
 
 const isPromise = require('is-promise')
 const pathRegexp = require('path-to-regexp')
+const debug = require('debug')('router:layer')
 
 /**
  * Module variables.
@@ -34,6 +35,7 @@ function Layer (path, options, fn) {
     return new Layer(path, options, fn)
   }
 
+  debug('new %o', path)
   const opts = options || {}
 
   this.handle = fn

--- a/lib/route.js
+++ b/lib/route.js
@@ -12,6 +12,7 @@
  * @private
  */
 
+const debug = require('debug')('router:route')
 const Layer = require('./layer')
 const { METHODS } = require('node:http')
 
@@ -43,6 +44,7 @@ module.exports = Route
  */
 
 function Route (path) {
+  debug('new %o', path)
   this.path = path
   this.stack = []
 
@@ -230,6 +232,8 @@ methods.forEach(function (method) {
       if (typeof fn !== 'function') {
         throw new TypeError('argument handler must be a function')
       }
+
+      debug('%s %s', method, this.path)
 
       const layer = Layer('/', {}, fn)
       layer.method = method

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "license": "MIT",
   "repository": "pillarjs/router",
   "dependencies": {
+    "debug": "^4.4.0",
     "is-promise": "^4.0.0",
     "parseurl": "^1.3.3",
     "path-to-regexp": "^8.0.0"


### PR DESCRIPTION
Revert "Remove debug dependency", with the following changes:

- Update "var" to "const" for debug imports
- Preserve history file so intermediate versions are documented correctly
- Use latest version of debug

This reverts commit 0b5a0a6b578565cc36712f8d5004566bf5e1472f.