### PR TITLE
feat: deprecate non-native Promises

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ const { METHODS } = require('node:http')
 const parseUrl = require('parseurl')
 const Route = require('./lib/route')
 const debug = require('debug')('router')
+const deprecate = require('depd')('router')
 
 /**
  * Module variables.
@@ -647,6 +648,10 @@ function processParams (params, layer, called, req, res, done) {
     try {
       const ret = fn(req, res, paramCallback, paramVal, key)
       if (isPromise(ret)) {
+        if (!(ret instanceof Promise)) {
+          deprecate('parameters that are Promise-like are deprecated, use a native Promise instead')
+        }
+
         ret.then(null, function (error) {
           paramCallback(error || new Error('Rejected promise'))
         })

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -15,6 +15,7 @@
 const isPromise = require('is-promise')
 const pathRegexp = require('path-to-regexp')
 const debug = require('debug')('router:layer')
+const deprecate = require('depd')('router')
 
 /**
  * Module variables.
@@ -116,6 +117,10 @@ Layer.prototype.handleError = function handleError (error, req, res, next) {
 
     // wait for returned promise
     if (isPromise(ret)) {
+      if (!(ret instanceof Promise)) {
+        deprecate('handlers that are Promise-like are deprecated, use a native Promise instead')
+      }
+
       ret.then(null, function (error) {
         next(error || new Error('Rejected promise'))
       })
@@ -148,6 +153,10 @@ Layer.prototype.handleRequest = function handleRequest (req, res, next) {
 
     // wait for returned promise
     if (isPromise(ret)) {
+      if (!(ret instanceof Promise)) {
+        deprecate('handlers that are Promise-like are deprecated, use a native Promise instead')
+      }
+
       ret.then(null, function (error) {
         next(error || new Error('Rejected promise'))
       })

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "repository": "pillarjs/router",
   "dependencies": {
     "debug": "^4.4.0",
+    "depd": "^2.0.0",
     "is-promise": "^4.0.0",
     "parseurl": "^1.3.3",
     "path-to-regexp": "^8.0.0"


### PR DESCRIPTION
Deprecates the use of Promises that are non-native so that the `is-promise` library can be replaced in the future with a simple `instanceof` check.

See also #137, #136