### PR TITLE
Add a helpful error message when pathRegexp fails

### DIFF
--- a/lib/layer.js
+++ b/lib/layer.js
@@ -83,12 +83,18 @@ function Layer (path, options, fn) {
       }
     }
 
-    return pathRegexp.match((opts.strict ? _path : loosen(_path)), {
-      sensitive: opts.sensitive,
-      end: opts.end,
-      trailing: !opts.strict,
-      decode: decodeParam
-    })
+    try {
+      return pathRegexp.match((opts.strict ? _path : loosen(_path)), {
+        sensitive: opts.sensitive,
+        end: opts.end,
+        trailing: !opts.strict,
+        decode: decodeParam
+      });
+    }
+    catch (err) {
+      console.error(err);
+      throw new Error(`The path route '${_path}' could not be parsed. Check the above error message for details.`);
+    }
   }
   this.matchers = Array.isArray(path) ? path.map(matcher) : [matcher(path)]
 }


### PR DESCRIPTION
I encountered this issue when migrating from Express v4 to v5. When I had route strings like '/*', it failed, but the error message I got was quite vague (but worse, it does NOT point to my violating line of code or show my violating string):

```
Error: TypeError: Missing parameter name at 2: https://git.new/pathToRegexpError
    at name (/workspaces/scoutradioz/primary/node_modules/path-to-regexp/src/index.ts:156:12)
    at lexer (/workspaces/scoutradioz/primary/node_modules/path-to-regexp/src/index.ts:173:6)
    at lexer.next (<anonymous>)
    at Iter.peek (/workspaces/scoutradioz/primary/node_modules/path-to-regexp/src/index.ts:190:6)
    at Iter.tryConsume (/workspaces/scoutradioz/primary/node_modules/path-to-regexp/src/index.ts:196:37)
    at Iter.text (/workspaces/scoutradioz/primary/node_modules/path-to-regexp/src/index.ts:215:6)
    at consume (/workspaces/scoutradioz/primary/node_modules/path-to-regexp/src/index.ts:286:29)
    at parse (/workspaces/scoutradioz/primary/node_modules/path-to-regexp/src/index.ts:322:2)
    at /workspaces/scoutradioz/primary/node_modules/path-to-regexp/src/index.ts:507:48
    at Array.map (<anonymous>)
```

Adding this try-catch will still spit out the error message provided by path-to-regexp, which points to their documentation where we can read more about the issue, but more importantly, the new error message/stack will contain the violating string and line of source code.

```
Error: The path route '/*' could not be parsed. Check the above error message for details.
    at matcher (/workspaces/scoutradioz/primary/node_modules/router/lib/layer.js:96:10)
    at new Layer (/workspaces/scoutradioz/primary/node_modules/router/lib/layer.js:99:61)
    at Function.route (/workspaces/scoutradioz/primary/node_modules/router/index.js:428:17)
    at Function.Router.<computed> [as get] (/workspaces/scoutradioz/primary/node_modules/router/index.js:447:24)
    at Object.<anonymous> (/workspaces/scoutradioz/primary/src/routes/scouting.ts:23:8)
    at Module._compile (node:internal/modules/cjs/loader:1565:14)
    at Module.m._compile (/workspaces/scoutradioz/node_modules/ts-node/src/index.ts:1618:23)
    at node:internal/modules/cjs/loader:1708:10
    at Object.require.extensions.<computed> [as .ts] (/workspaces/scoutradioz/node_modules/ts-node/src/index.ts:1621:12)
    at Module.load (node:internal/modules/cjs/loader:1318:32)
```