### PR TITLE
docs: fix typo in .all doc comment

### DIFF
--- a/lib/route.js
+++ b/lib/route.js
@@ -167,7 +167,7 @@ Route.prototype.dispatch = function dispatch (req, res, done) {
  * Behaves just like middleware and can respond or call `next`
  * to continue processing.
  *
- * You can use multiple `.all` call to add multiple handlers.
+ * You can use multiple `.all` calls to add multiple handlers.
  *
  *   function check_something(req, res, next){
  *     next()


### PR DESCRIPTION
`call` should be pluralized in `multiple call[s]`