### PR TITLE
test: skip query test on node <22

### DIFF
--- a/test/route.js
+++ b/test/route.js
@@ -11,6 +11,7 @@ const shouldHaveBody = utils.shouldHaveBody
 const shouldHitHandle = utils.shouldHitHandle
 const shouldNotHaveBody = utils.shouldNotHaveBody
 const shouldNotHitHandle = utils.shouldNotHitHandle
+const shouldSkipQueryHttpMethod = utils.shouldSkipQueryHttpMethod
 const methods = utils.methods
 
 describe('Router', function () {
@@ -255,9 +256,7 @@ describe('Router', function () {
         return
       }
 
-      // Skipping HTTP QUERY tests below Node 22, QUERY wasn't fully supported by Node until 22
-      const majorVersion = Number(process.versions.node.split('.')[0]);
-      if (method === 'query' && majorVersion < 22) {
+      if (shouldSkipQueryHttpMethod()) {
         return
       }
 

--- a/test/route.js
+++ b/test/route.js
@@ -254,7 +254,10 @@ describe('Router', function () {
         // CONNECT is tricky and supertest doesn't support it
         return
       }
-      if (method === 'query' && process.version.startsWith('v21')) {
+
+      // Skipping HTTP QUERY tests below Node 22, QUERY wasn't fully supported by Node until 22
+      const majorVersion = Number(process.versions.node.split('.')[0]);
+      if (method === 'query' && majorVersion < 22) {
         return
       }
 

--- a/test/router.js
+++ b/test/router.js
@@ -51,7 +51,10 @@ describe('Router', function () {
             // CONNECT is tricky and supertest doesn't support it
             return cb()
           }
-          if (method === 'query' && process.version.startsWith('v21')) {
+
+          // Skipping HTTP QUERY tests below Node 22, QUERY wasn't fully supported by Node until 22
+          const majorVersion = Number(process.versions.node.split('.')[0]);
+          if (method === 'query' && majorVersion < 22) {
             return cb()
           }
 
@@ -317,7 +320,10 @@ describe('Router', function () {
       // CONNECT is tricky and supertest doesn't support it
       return
     }
-    if (method === 'query' && process.version.startsWith('v21')) {
+    
+    // Skipping HTTP QUERY tests below Node 22, QUERY wasn't fully supported by Node until 22
+    const majorVersion = Number(process.versions.node.split('.')[0]);
+    if (method === 'query' && majorVersion < 22) {
       return
     }
 

--- a/test/router.js
+++ b/test/router.js
@@ -319,7 +319,7 @@ describe('Router', function () {
       // CONNECT is tricky and supertest doesn't support it
       return
     }
-    
+
     if (shouldSkipQueryHttpMethod()) {
       return
     }

--- a/test/router.js
+++ b/test/router.js
@@ -12,6 +12,7 @@ const shouldHaveBody = utils.shouldHaveBody
 const shouldHitHandle = utils.shouldHitHandle
 const shouldNotHaveBody = utils.shouldNotHaveBody
 const shouldNotHitHandle = utils.shouldNotHitHandle
+const shouldSkipQueryHttpMethod = utils.shouldSkipQueryHttpMethod
 const methods = utils.methods
 
 describe('Router', function () {
@@ -52,9 +53,7 @@ describe('Router', function () {
             return cb()
           }
 
-          // Skipping HTTP QUERY tests below Node 22, QUERY wasn't fully supported by Node until 22
-          const majorVersion = Number(process.versions.node.split('.')[0]);
-          if (method === 'query' && majorVersion < 22) {
+          if (shouldSkipQueryHttpMethod()) {
             return cb()
           }
 
@@ -321,9 +320,7 @@ describe('Router', function () {
       return
     }
     
-    // Skipping HTTP QUERY tests below Node 22, QUERY wasn't fully supported by Node until 22
-    const majorVersion = Number(process.versions.node.split('.')[0]);
-    if (method === 'query' && majorVersion < 22) {
+    if (shouldSkipQueryHttpMethod()) {
       return
     }
 

--- a/test/support/utils.js
+++ b/test/support/utils.js
@@ -15,6 +15,7 @@ exports.shouldHaveBody = shouldHaveBody
 exports.shouldNotHaveBody = shouldNotHaveBody
 exports.shouldHitHandle = shouldHitHandle
 exports.shouldNotHitHandle = shouldNotHitHandle
+exports.shouldSkipQueryHttpMethod = shouldSkipQueryHttpMethod
 exports.methods = methods
 
 function createHitHandle (num) {
@@ -139,4 +140,10 @@ function shouldNotHaveHeader (header) {
   return function (res) {
     assert.ok(!(header.toLowerCase() in res.headers), 'should not have header ' + header)
   }
+}
+
+// Skipping HTTP QUERY tests below Node 22, QUERY wasn't fully supported by Node until 22
+function shouldSkipQueryHttpMethod() {
+  const majorVersion = Number(process.versions.node.split('.')[0]);
+  return majorVersion < 22;
 }

--- a/test/support/utils.js
+++ b/test/support/utils.js
@@ -143,7 +143,7 @@ function shouldNotHaveHeader (header) {
 }
 
 // Skipping HTTP QUERY tests below Node 22, QUERY wasn't fully supported by Node until 22
-function shouldSkipQueryHttpMethod() {
-  const majorVersion = Number(process.versions.node.split('.')[0]);
-  return majorVersion < 22;
+function shouldSkipQueryHttpMethod () {
+  const majorVersion = Number(process.versions.node.split('.')[0])
+  return majorVersion < 22
 }


### PR DESCRIPTION
Follow-up to https://github.com/pillarjs/router/issues/162#issuecomment-3016193694

> This is due to the latest Node.js security patch, it's probably enough to just skip that test
>
> https://github.com/expressjs/express/pull/6512

This mirrors the Express PR (https://github.com/expressjs/express/pull/6512) and skips testing the `QUERY` method on Node <22 in this repository too.