### PR TITLE
fix: set statusCode property on error in layer.js to ensure proper error handling

### DIFF
--- a/lib/layer.js
+++ b/lib/layer.js
@@ -226,7 +226,7 @@ function decodeParam (val) {
   } catch (err) {
     if (err instanceof URIError) {
       err.message = 'Failed to decode param \'' + val + '\''
-      err.status = 400
+      err.status = err.statusCode = 400
     }
 
     throw err


### PR DESCRIPTION
### Description

When using this router with Next.js, which relies on the `statusCode` property (and **not** `status`), errors incorrectly default to a 500 status because Next.js does not read the `status` property.

In Express 4.x, both `status` and `statusCode` were set on error objects. However, in this version, only `status` is set. This causes compatibility issues with Next.js, resulting in incorrect HTTP status codes being returned.

This fix ensures that the `statusCode` property is also set on error objects in `layer.js`, restoring compatibility with Next.js and preventing erroneous 500 responses.
