### PR TITLE
layer: use empty object without prototype for params of regexp path

### DIFF
--- a/lib/layer.js
+++ b/lib/layer.js
@@ -65,7 +65,8 @@ function Layer (path, options, fn) {
           return false
         }
 
-        const params = {}
+        const params = { __proto__: null }
+
         for (let i = 1; i < match.length; i++) {
           const key = keys[i - 1]
           const prop = key.name


### PR DESCRIPTION
as was discovered here https://github.com/expressjs/expressjs.com/pull/2092, params will have an object with a prototype depending on whether its path is a string or a regexp, this PR tries to unify so that both are without a prototype, given that for a string path the params are created without a prototype [here](https://github.com/pillarjs/path-to-regexp/blob/05a5a973702a863fb69415294503d13cb9d18b20/src/index.ts#L451), whereas when it's a regexp it's created [here](https://github.com/pillarjs/router/blob/cb2a5fcdf31b9cc92296183ceeff8126b5c57453/lib/layer.js#L68)

 we consider this a breaking change? I don't think so, the impact would be minimal and I don't think anyone is accessing the prototype of params