### PR TITLE
feat: add request layer lifecycle TracingChannels

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,56 @@ router.route('/pet/:id')
 server.listen(8080)
 ```
 
+## Diagnostics
+
+`router` integrates with Node.js [`diagnostics_channel`](https://nodejs.org/api/diagnostics_channel.html)
+via a [`TracingChannel`](https://nodejs.org/api/diagnostics_channel.html#class-tracingchannel)
+named `pillarjs.router.request`. This lets observability tools (APMs, tracers,
+loggers) hook into middleware and route handler execution without monkey-patching.
+
+Each layer's handler invocation publishes the standard tracing channel sub-events
+(`start`, `end`, `asyncStart`, `asyncEnd`, `error`). The published context object
+contains:
+
+- `req`: the incoming `http.IncomingMessage`
+- `res`: the `http.ServerResponse`
+- `layer`: the internal `Layer` instance being invoked (exposes `.name`, `.path`, `.handle`, etc.). Note that `Layer` is an internal implementation detail and its shape may change between releases.
+- `error`: the error passed to `next(err)`, when applicable
+- `handled`: `true` when the layer is an error-handling middleware (4-arg signature)
+
+The `error` event is also published when a handler calls `next(err)` with a real
+error. The control-flow sentinels `'route'` and `'router'` are not treated as
+errors and will not publish to the `error` channel.
+
+When no subscribers are attached, tracing is bypassed entirely, so there is no
+context allocation or channel publishing overhead on the hot path.
+
+```js
+const dc = require('node:diagnostics_channel')
+
+const channel = dc.tracingChannel('pillarjs.router.request')
+
+channel.subscribe({
+  start (ctx) {
+    ctx.startTime = process.hrtime.bigint()
+  },
+  end (ctx) {
+    // do whatever you need on synchronous completion
+  },
+  asyncStart (ctx) {
+    // do whatever you need when the async portion begins
+  },
+  asyncEnd (ctx) {
+    const durationNs = process.hrtime.bigint() - ctx.startTime
+    console.log('%s %s -> %s (%dns)',
+      ctx.req.method, ctx.req.url, ctx.layer.name, durationNs)
+  },
+  error (ctx) {
+    console.error('handler error in %s:', ctx.layer.name, ctx.error)
+  }
+})
+```
+
 ## License
 
 [MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ server.listen(8080)
 
 `router` integrates with Node.js [`diagnostics_channel`](https://nodejs.org/api/diagnostics_channel.html)
 via a [`TracingChannel`](https://nodejs.org/api/diagnostics_channel.html#class-tracingchannel)
-named `pillarjs.router.request`. This lets observability tools (APMs, tracers,
+named `express.router.request`. This lets observability tools (APMs, tracers,
 loggers) hook into middleware and route handler execution without monkey-patching.
 
 Each layer's handler invocation publishes the standard tracing channel sub-events
@@ -427,7 +427,7 @@ context allocation or channel publishing overhead on the hot path.
 ```js
 const dc = require('node:diagnostics_channel')
 
-const channel = dc.tracingChannel('pillarjs.router.request')
+const channel = dc.tracingChannel('express.router.request')
 
 channel.subscribe({
   start (ctx) {

--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ contains:
 - `res`: the `http.ServerResponse`
 - `layer`: the internal `Layer` instance being invoked (exposes `.name`, `.path`, `.handle`, etc.). Note that `Layer` is an internal implementation detail and its shape may change between releases.
 - `error`: the error the layer failed with, when applicable
-- `handled`: `true` when the layer is an error-handling middleware (4-arg signature)
+- `errorHandler`: `true` when the layer is an error-handling middleware (4-arg signature)
 
 The `error` event is published once, on the layer where the error originates,
 whether the handler calls `next(err)`, throws, or returns a rejected promise. An

--- a/README.md
+++ b/README.md
@@ -414,12 +414,14 @@ contains:
 - `req`: the incoming `http.IncomingMessage`
 - `res`: the `http.ServerResponse`
 - `layer`: the internal `Layer` instance being invoked (exposes `.name`, `.path`, `.handle`, etc.). Note that `Layer` is an internal implementation detail and its shape may change between releases.
-- `error`: the error passed to `next(err)`, when applicable
+- `error`: the error the layer failed with, when applicable
 - `handled`: `true` when the layer is an error-handling middleware (4-arg signature)
 
-The `error` event is also published when a handler calls `next(err)` with a real
-error. The control-flow sentinels `'route'` and `'router'` are not treated as
-errors and will not publish to the `error` channel.
+The `error` event is published once, on the layer where the error originates,
+whether the handler calls `next(err)`, throws, or returns a rejected promise. An
+error bubbling up through outer layers is not reported again. The `'route'` and
+`'router'` routing signals are not treated as errors and will not publish to the
+`error` channel.
 
 When no subscribers are attached, tracing is bypassed entirely, so there is no
 context allocation or channel publishing overhead on the hot path.

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -218,6 +218,12 @@ function recordError (req, err) {
   return true
 }
 
+// 'route' and 'router' signal to exit the route / router (see route.js), not
+// real errors.
+function isRoutingSignal (err) {
+  return err === 'route' || err === 'router'
+}
+
 /**
  * Invoke a handler wrapped in the request TracingChannel. Only called when the
  * channel has subscribers, so ctx is always present.
@@ -226,10 +232,9 @@ function recordError (req, err) {
 
 function invokeWithTrace (exec, ctx, next) {
   const wrappedNext = function (err) {
-    // 'route' and 'router' are control-flow sentinels (skip route / exit router),
-    // not real errors — don't pollute the error channel with them. An error that
-    // already bubbled up from an inner layer is only reported at its origin.
-    if (err && err !== 'route' && err !== 'router' && recordError(ctx.req, err)) {
+    // Don't pollute the error channel with routing signals, and only report an
+    // error at its origin, not again as it bubbles up through outer layers.
+    if (err && !isRoutingSignal(err) && recordError(ctx.req, err)) {
       ctx.error = err
       requestChannel.error.publish(ctx)
     }
@@ -237,7 +242,30 @@ function invokeWithTrace (exec, ctx, next) {
   }
 
   try {
-    const ret = requestChannel.tracePromise(function () { return handlePromise(exec(wrappedNext)) }, ctx)
+    const ret = requestChannel.tracePromise(function () {
+      // Catch thrown/rejected routing signals here so tracePromise doesn't
+      // report them as errors; real errors propagate and are reported as usual.
+      let out
+      try {
+        out = handlePromise(exec(wrappedNext))
+      } catch (err) {
+        if (isRoutingSignal(err)) {
+          next(err)
+          return
+        }
+        throw err
+      }
+
+      if (out) {
+        return out.then(undefined, function (err) {
+          if (isRoutingSignal(err)) {
+            next(err)
+            return
+          }
+          throw err
+        })
+      }
+    }, ctx)
 
     if (ret) {
       ret.then(null, function (error) {

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -33,11 +33,15 @@ const MATCHING_GROUP_REGEXP = /\((?:\?<(.*?)>)?(?!\?)/g
 
 const requestChannel = dc.tracingChannel && dc.tracingChannel('express.router.request')
 
-/**
- * Check if the channel has subscribers.
- */
+// TracingChannel#hasSubscribers is undefined before Node 20.13/22, so check the sub-channels.
 function shouldTrace (ch) {
-  return ch && ch.hasSubscribers !== false
+  return Boolean(ch) && (
+    ch.start.hasSubscribers ||
+    ch.end.hasSubscribers ||
+    ch.asyncStart.hasSubscribers ||
+    ch.asyncEnd.hasSubscribers ||
+    ch.error.hasSubscribers
+  )
 }
 
 /**

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -241,10 +241,10 @@ function invokeWithTrace (exec, ctx, next) {
     next(err)
   }
 
-  // All outcomes flow through wrappedNext (never tracePromise's own error
-  // publishing), so signal filtering and dedup happen in one place and tracing
-  // never changes how the router routes.
-  requestChannel.tracePromise(function () {
+  // runStores fires `start` and sets the async context; the rest are published
+  // manually, so a synchronous layer emits only start/end. All outcomes flow
+  // through wrappedNext to keep signal filtering and dedup in one place.
+  requestChannel.start.runStores(ctx, function () {
     let out
     try {
       out = handlePromise(exec(wrappedNext))
@@ -252,17 +252,30 @@ function invokeWithTrace (exec, ctx, next) {
       // A sync throw is forwarded verbatim, so a falsy value keeps routing
       // exactly as the untraced path does.
       wrappedNext(err)
+      requestChannel.end.publish(ctx)
       return
     }
 
-    if (out) {
-      return out.then(undefined, function (err) {
+    if (!out) {
+      requestChannel.end.publish(ctx)
+      return
+    }
+
+    requestChannel.end.publish(ctx)
+    out.then(
+      function () {
+        requestChannel.asyncStart.publish(ctx)
+        requestChannel.asyncEnd.publish(ctx)
+      },
+      function (err) {
         // A rejected promise is an error even when the reason is falsy;
         // normalize it to the error the router forwards to next().
         wrappedNext(err || new Error('Rejected promise'))
-      })
-    }
-  }, ctx)
+        requestChannel.asyncStart.publish(ctx)
+        requestChannel.asyncEnd.publish(ctx)
+      }
+    )
+  })
 }
 
 /**

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -31,7 +31,7 @@ const MATCHING_GROUP_REGEXP = /\((?:\?<(.*?)>)?(?!\?)/g
  * @private
  */
 
-const requestChannel = dc.tracingChannel && dc.tracingChannel('express:request')
+const requestChannel = dc.tracingChannel && dc.tracingChannel('pillarjs.router.request')
 
 /**
  * Check if the channel has subscribers.

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -154,7 +154,7 @@ Layer.prototype.handleError = function handleError (error, req, res, next) {
   const layer = this
   invokeWithTrace(function (wrappedNext) {
     return fn(error, req, res, wrappedNext)
-  }, { req, res, layer, error, handled: true }, next)
+  }, { req, res, layer, error, errorHandler: true }, next)
 }
 
 /**

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -37,7 +37,7 @@ const requestChannel = dc.tracingChannel && dc.tracingChannel('express:request')
  * Check if the channel has subscribers.
  */
 function shouldTrace (ch) {
-  return ch && ch.start.hasSubscribers !== false
+  return ch && ch.hasSubscribers !== false
 }
 
 /**

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -180,7 +180,9 @@ function invokeWithTrace (exec, ctxFactory, next) {
   const ctx = tracing ? ctxFactory() : null
   const wrappedNext = tracing
     ? function (err) {
-      if (err) {
+      // 'route' and 'router' are control-flow sentinels (skip route / exit router),
+      // not real errors — don't pollute the error channel with them.
+      if (err && err !== 'route' && err !== 'router') {
         ctx.error = err
         // Explicitly publish the error to the error channel
         requestChannel.error.publish(ctx)

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -31,7 +31,7 @@ const MATCHING_GROUP_REGEXP = /\((?:\?<(.*?)>)?(?!\?)/g
  * @private
  */
 
-const requestChannel = dc.tracingChannel('express:request')
+const requestChannel = dc.tracingChannel && dc.tracingChannel('express:request')
 
 /**
  * Check if the channel has subscribers.

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -232,8 +232,8 @@ function isRoutingSignal (err) {
 
 function invokeWithTrace (exec, ctx, next) {
   const wrappedNext = function (err) {
-    // Don't pollute the error channel with routing signals, and only report an
-    // error at its origin, not again as it bubbles up through outer layers.
+    // Routing signals aren't errors; only report a real error once, at its
+    // origin, not again as it bubbles up through outer layers.
     if (err && !isRoutingSignal(err) && recordError(ctx.req, err)) {
       ctx.error = err
       requestChannel.error.publish(ctx)
@@ -241,48 +241,28 @@ function invokeWithTrace (exec, ctx, next) {
     next(err)
   }
 
-  try {
-    const ret = requestChannel.tracePromise(function () {
-      // Catch thrown/rejected routing signals here so tracePromise doesn't
-      // report them as errors; real errors propagate and are reported as usual.
-      // A falsy rejection is normalized to the same error the router forwards to
-      // next(), so the error channel and downstream handlers see one instance.
-      let out
-      try {
-        out = handlePromise(exec(wrappedNext))
-      } catch (err) {
-        if (isRoutingSignal(err)) {
-          next(err)
-          return
-        }
-        throw err || new Error('Rejected promise')
-      }
+  // All outcomes flow through wrappedNext (never tracePromise's own error
+  // publishing), so signal filtering and dedup happen in one place and tracing
+  // never changes how the router routes.
+  requestChannel.tracePromise(function () {
+    let out
+    try {
+      out = handlePromise(exec(wrappedNext))
+    } catch (err) {
+      // A sync throw is forwarded verbatim, so a falsy value keeps routing
+      // exactly as the untraced path does.
+      wrappedNext(err)
+      return
+    }
 
-      if (out) {
-        return out.then(undefined, function (err) {
-          if (isRoutingSignal(err)) {
-            next(err)
-            return
-          }
-          throw err || new Error('Rejected promise')
-        })
-      }
-    }, ctx)
-
-    if (ret) {
-      ret.then(null, function (error) {
-        // tracePromise already reported the rejection on this layer (with the
-        // normalized error); record it so outer layers don't report it again.
-        recordError(ctx.req, error)
-        next(error)
+    if (out) {
+      return out.then(undefined, function (err) {
+        // A rejected promise is an error even when the reason is falsy;
+        // normalize it to the error the router forwards to next().
+        wrappedNext(err || new Error('Rejected promise'))
       })
     }
-  } catch (err) {
-    // tracePromise already reported the sync throw on this layer; record it so
-    // outer layers don't report it again.
-    recordError(ctx.req, err)
-    next(err)
-  }
+  }, ctx)
 }
 
 /**

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -245,6 +245,8 @@ function invokeWithTrace (exec, ctx, next) {
     const ret = requestChannel.tracePromise(function () {
       // Catch thrown/rejected routing signals here so tracePromise doesn't
       // report them as errors; real errors propagate and are reported as usual.
+      // A falsy rejection is normalized to the same error the router forwards to
+      // next(), so the error channel and downstream handlers see one instance.
       let out
       try {
         out = handlePromise(exec(wrappedNext))
@@ -253,7 +255,7 @@ function invokeWithTrace (exec, ctx, next) {
           next(err)
           return
         }
-        throw err
+        throw err || new Error('Rejected promise')
       }
 
       if (out) {
@@ -262,17 +264,17 @@ function invokeWithTrace (exec, ctx, next) {
             next(err)
             return
           }
-          throw err
+          throw err || new Error('Rejected promise')
         })
       }
     }, ctx)
 
     if (ret) {
       ret.then(null, function (error) {
-        // tracePromise already reported the rejection on this layer; record it
-        // so outer layers don't report it again.
+        // tracePromise already reported the rejection on this layer (with the
+        // normalized error); record it so outer layers don't report it again.
         recordError(ctx.req, error)
-        next(error || new Error('Rejected promise'))
+        next(error)
       })
     }
   } catch (err) {

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -31,7 +31,7 @@ const MATCHING_GROUP_REGEXP = /\((?:\?<(.*?)>)?(?!\?)/g
  * @private
  */
 
-const requestChannel = dc.tracingChannel && dc.tracingChannel('pillarjs.router.request')
+const requestChannel = dc.tracingChannel && dc.tracingChannel('express.router.request')
 
 /**
  * Check if the channel has subscribers.

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -176,39 +176,32 @@ Layer.prototype.handleRequest = function handleRequest (req, res, next) {
  */
 
 function invokeWithTrace (exec, ctxFactory, next) {
-  if (ctxFactory && shouldTrace(requestChannel)) {
-    try {
-      requestChannel.tracePromise(function () {
-        const ret = exec()
-        if (isPromise(ret)) {
-          if (!(ret instanceof Promise)) {
-            deprecate('handlers that are Promise-like are deprecated, use a native Promise instead')
-          }
-          return ret
-        }
-      }, ctxFactory()).then(null, function (error) {
-        next(error || new Error('Rejected promise'))
-      })
-    } catch (err) {
-      next(err)
-    }
-    return
-  }
-
   try {
-    const ret = exec()
+    const ret = (ctxFactory && shouldTrace(requestChannel))
+      ? requestChannel.tracePromise(function () { return handlePromise(exec()) }, ctxFactory())
+      : handlePromise(exec())
 
-    if (isPromise(ret)) {
-      if (!(ret instanceof Promise)) {
-        deprecate('handlers that are Promise-like are deprecated, use a native Promise instead')
-      }
-
+    if (ret) {
       ret.then(null, function (error) {
         next(error || new Error('Rejected promise'))
       })
     }
   } catch (err) {
     next(err)
+  }
+}
+
+/**
+ * If the return value is a promise, validate it and return it.
+ * @private
+ */
+
+function handlePromise (ret) {
+  if (isPromise(ret)) {
+    if (!(ret instanceof Promise)) {
+      deprecate('handlers that are Promise-like are deprecated, use a native Promise instead')
+    }
+    return ret
   }
 }
 

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -33,6 +33,10 @@ const MATCHING_GROUP_REGEXP = /\((?:\?<(.*?)>)?(?!\?)/g
 
 const requestChannel = dc.tracingChannel && dc.tracingChannel('express.router.request')
 
+// Tracks errors already reported for a request so the same error bubbling up
+// through mounted routers or forwarding error handlers is only reported once.
+const publishedErrors = Symbol('router.tracing.publishedErrors')
+
 // TracingChannel#hasSubscribers is undefined before Node 20.13/22, so check the sub-channels.
 function shouldTrace (ch) {
   return Boolean(ch) && (
@@ -198,6 +202,23 @@ Layer.prototype.handleRequest = function handleRequest (req, res, next) {
 }
 
 /**
+ * Record an error as reported for this request. Returns false when the same
+ * error was already reported, so it isn't published again as it bubbles up.
+ * @private
+ */
+
+function recordError (req, err) {
+  let seen = req[publishedErrors]
+  if (!seen) {
+    seen = req[publishedErrors] = new Set()
+  } else if (seen.has(err)) {
+    return false
+  }
+  seen.add(err)
+  return true
+}
+
+/**
  * Invoke a handler wrapped in the request TracingChannel. Only called when the
  * channel has subscribers, so ctx is always present.
  * @private
@@ -206,10 +227,10 @@ Layer.prototype.handleRequest = function handleRequest (req, res, next) {
 function invokeWithTrace (exec, ctx, next) {
   const wrappedNext = function (err) {
     // 'route' and 'router' are control-flow sentinels (skip route / exit router),
-    // not real errors — don't pollute the error channel with them.
-    if (err && err !== 'route' && err !== 'router') {
+    // not real errors — don't pollute the error channel with them. An error that
+    // already bubbled up from an inner layer is only reported at its origin.
+    if (err && err !== 'route' && err !== 'router' && recordError(ctx.req, err)) {
       ctx.error = err
-      // Explicitly publish the error to the error channel
       requestChannel.error.publish(ctx)
     }
     next(err)
@@ -220,10 +241,16 @@ function invokeWithTrace (exec, ctx, next) {
 
     if (ret) {
       ret.then(null, function (error) {
+        // tracePromise already reported the rejection on this layer; record it
+        // so outer layers don't report it again.
+        recordError(ctx.req, error)
         next(error || new Error('Rejected promise'))
       })
     }
   } catch (err) {
+    // tracePromise already reported the sync throw on this layer; record it so
+    // outer layers don't report it again.
+    recordError(ctx.req, err)
     next(err)
   }
 }

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -127,10 +127,10 @@ Layer.prototype.handleError = function handleError (error, req, res, next) {
   }
 
   const layer = this
-  invokeWithTrace(function () {
-    return fn(error, req, res, next)
+  invokeWithTrace(function (wrappedNext) {
+    return fn(error, req, res, wrappedNext)
   }, function () {
-    return { req, res, layer }
+    return { req, res, layer, error, handled: true }
   }, next)
 }
 
@@ -155,14 +155,14 @@ Layer.prototype.handleRequest = function handleRequest (req, res, next) {
   // the internal layer that calls route.dispatch). The actual user handlers
   // inside the route are traced individually.
   if (this.route) {
-    return invokeWithTrace(function () {
-      return fn(req, res, next)
+    return invokeWithTrace(function (wrappedNext) {
+      return fn(req, res, wrappedNext)
     }, null, next)
   }
 
   const layer = this
-  invokeWithTrace(function () {
-    return fn(req, res, next)
+  invokeWithTrace(function (wrappedNext) {
+    return fn(req, res, wrappedNext)
   }, function () {
     return { req, res, layer }
   }, next)
@@ -176,10 +176,23 @@ Layer.prototype.handleRequest = function handleRequest (req, res, next) {
  */
 
 function invokeWithTrace (exec, ctxFactory, next) {
+  const tracing = ctxFactory && shouldTrace(requestChannel)
+  const ctx = tracing ? ctxFactory() : null
+  const wrappedNext = tracing
+    ? function (err) {
+      if (err) {
+        ctx.error = err
+        // Explicitly publish the error to the error channel
+        requestChannel.error.publish(ctx)
+      }
+      next(err)
+    }
+    : next
+
   try {
-    const ret = (ctxFactory && shouldTrace(requestChannel))
-      ? requestChannel.tracePromise(function () { return handlePromise(exec()) }, ctxFactory())
-      : handlePromise(exec())
+    const ret = tracing
+      ? requestChannel.tracePromise(function () { return handlePromise(exec(wrappedNext)) }, ctx)
+      : handlePromise(exec(wrappedNext))
 
     if (ret) {
       ret.then(null, function (error) {

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -12,7 +12,7 @@
  * @private
  */
 
-const dc = require('diagnostics_channel')
+const dc = require('node:diagnostics_channel')
 const isPromise = require('is-promise')
 const pathRegexp = require('path-to-regexp')
 const debug = require('debug')('router:layer')

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -12,6 +12,7 @@
  * @private
  */
 
+const dc = require('diagnostics_channel')
 const isPromise = require('is-promise')
 const pathRegexp = require('path-to-regexp')
 const debug = require('debug')('router:layer')
@@ -24,6 +25,20 @@ const deprecate = require('depd')('router')
 
 const TRAILING_SLASH_REGEXP = /\/+$/
 const MATCHING_GROUP_REGEXP = /\((?:\?<(.*?)>)?(?!\?)/g
+
+/**
+ * TracingChannel setup.
+ * @private
+ */
+
+const requestChannel = dc.tracingChannel('express:request')
+
+/**
+ * Check if the channel has subscribers.
+ */
+function shouldTrace (ch) {
+  return ch && ch.start.hasSubscribers !== false
+}
 
 /**
  * Expose `Layer`.
@@ -111,23 +126,12 @@ Layer.prototype.handleError = function handleError (error, req, res, next) {
     return next(error)
   }
 
-  try {
-    // invoke function
-    const ret = fn(error, req, res, next)
-
-    // wait for returned promise
-    if (isPromise(ret)) {
-      if (!(ret instanceof Promise)) {
-        deprecate('handlers that are Promise-like are deprecated, use a native Promise instead')
-      }
-
-      ret.then(null, function (error) {
-        next(error || new Error('Rejected promise'))
-      })
-    }
-  } catch (err) {
-    next(err)
-  }
+  const layer = this
+  invokeWithTrace(function () {
+    return fn(error, req, res, next)
+  }, function () {
+    return { req, res, layer }
+  }, next)
 }
 
 /**
@@ -147,11 +151,53 @@ Layer.prototype.handleRequest = function handleRequest (req, res, next) {
     return next()
   }
 
-  try {
-    // invoke function
-    const ret = fn(req, res, next)
+  // Skip tracing for route dispatch wrappers (this.route is only set on
+  // the internal layer that calls route.dispatch). The actual user handlers
+  // inside the route are traced individually.
+  if (this.route) {
+    return invokeWithTrace(function () {
+      return fn(req, res, next)
+    }, null, next)
+  }
 
-    // wait for returned promise
+  const layer = this
+  invokeWithTrace(function () {
+    return fn(req, res, next)
+  }, function () {
+    return { req, res, layer }
+  }, next)
+}
+
+/**
+ * Invoke a handler function, optionally wrapping it in TracingChannel.
+ * The ctxFactory is only called when tracing is active, ensuring zero
+ * allocation overhead when no subscribers are registered.
+ * @private
+ */
+
+function invokeWithTrace (exec, ctxFactory, next) {
+  if (ctxFactory && shouldTrace(requestChannel)) {
+    try {
+      requestChannel.tracePromise(function () {
+        const ret = exec()
+        if (isPromise(ret)) {
+          if (!(ret instanceof Promise)) {
+            deprecate('handlers that are Promise-like are deprecated, use a native Promise instead')
+          }
+          return ret
+        }
+      }, ctxFactory()).then(null, function (error) {
+        next(error || new Error('Rejected promise'))
+      })
+    } catch (err) {
+      next(err)
+    }
+    return
+  }
+
+  try {
+    const ret = exec()
+
     if (isPromise(ret)) {
       if (!(ret instanceof Promise)) {
         deprecate('handlers that are Promise-like are deprecated, use a native Promise instead')

--- a/lib/layer.js
+++ b/lib/layer.js
@@ -130,12 +130,27 @@ Layer.prototype.handleError = function handleError (error, req, res, next) {
     return next(error)
   }
 
+  if (!shouldTrace(requestChannel)) {
+    try {
+      // invoke function
+      const ret = handlePromise(fn(error, req, res, next))
+
+      // wait for returned promise
+      if (ret) {
+        ret.then(null, function (error) {
+          next(error || new Error('Rejected promise'))
+        })
+      }
+    } catch (err) {
+      next(err)
+    }
+    return
+  }
+
   const layer = this
   invokeWithTrace(function (wrappedNext) {
     return fn(error, req, res, wrappedNext)
-  }, function () {
-    return { req, res, layer, error, handled: true }
-  }, next)
+  }, { req, res, layer, error, handled: true }, next)
 }
 
 /**
@@ -155,50 +170,53 @@ Layer.prototype.handleRequest = function handleRequest (req, res, next) {
     return next()
   }
 
-  // Skip tracing for route dispatch wrappers (this.route is only set on
-  // the internal layer that calls route.dispatch). The actual user handlers
-  // inside the route are traced individually.
-  if (this.route) {
-    return invokeWithTrace(function (wrappedNext) {
-      return fn(req, res, wrappedNext)
-    }, null, next)
+  // Skip tracing for route dispatch wrappers (this.route is only set on the
+  // internal layer that calls route.dispatch); the user handlers inside the
+  // route are traced individually. Also skip when there are no subscribers,
+  // to avoid allocating a context object on every request.
+  if (this.route || !shouldTrace(requestChannel)) {
+    try {
+      // invoke function
+      const ret = handlePromise(fn(req, res, next))
+
+      // wait for returned promise
+      if (ret) {
+        ret.then(null, function (error) {
+          next(error || new Error('Rejected promise'))
+        })
+      }
+    } catch (err) {
+      next(err)
+    }
+    return
   }
 
   const layer = this
   invokeWithTrace(function (wrappedNext) {
     return fn(req, res, wrappedNext)
-  }, function () {
-    return { req, res, layer }
-  }, next)
+  }, { req, res, layer }, next)
 }
 
 /**
- * Invoke a handler function, optionally wrapping it in TracingChannel.
- * The ctxFactory is only called when tracing is active, ensuring zero
- * allocation overhead when no subscribers are registered.
+ * Invoke a handler wrapped in the request TracingChannel. Only called when the
+ * channel has subscribers, so ctx is always present.
  * @private
  */
 
-function invokeWithTrace (exec, ctxFactory, next) {
-  const tracing = ctxFactory && shouldTrace(requestChannel)
-  const ctx = tracing ? ctxFactory() : null
-  const wrappedNext = tracing
-    ? function (err) {
-      // 'route' and 'router' are control-flow sentinels (skip route / exit router),
-      // not real errors — don't pollute the error channel with them.
-      if (err && err !== 'route' && err !== 'router') {
-        ctx.error = err
-        // Explicitly publish the error to the error channel
-        requestChannel.error.publish(ctx)
-      }
-      next(err)
+function invokeWithTrace (exec, ctx, next) {
+  const wrappedNext = function (err) {
+    // 'route' and 'router' are control-flow sentinels (skip route / exit router),
+    // not real errors — don't pollute the error channel with them.
+    if (err && err !== 'route' && err !== 'router') {
+      ctx.error = err
+      // Explicitly publish the error to the error channel
+      requestChannel.error.publish(ctx)
     }
-    : next
+    next(err)
+  }
 
   try {
-    const ret = tracing
-      ? requestChannel.tracePromise(function () { return handlePromise(exec(wrappedNext)) }, ctx)
-      : handlePromise(exec(wrappedNext))
+    const ret = requestChannel.tracePromise(function () { return handlePromise(exec(wrappedNext)) }, ctx)
 
     if (ret) {
       ret.then(null, function (error) {

--- a/test/tracing.js
+++ b/test/tracing.js
@@ -547,11 +547,21 @@ describeTracing('TracingChannel', function () {
           if (err) return done(err)
 
           const errorEvents = events.filter(function (e) { return e.phase === 'error' })
-          const layerNames = errorEvents.map(function (e) { return e.ctx.layer.name })
+          const byName = function (name) {
+            return errorEvents.find(function (e) { return e.ctx.layer.name === name })
+          }
 
           assert.equal(errorEvents.length, 2, 'error should fire on both layers')
-          assert.ok(layerNames.includes('throwingHandler'), 'route layer should emit error')
-          assert.ok(layerNames.includes('throwingErrorHandler'), 'error handler should emit its own error')
+
+          const routeError = byName('throwingHandler')
+          assert.ok(routeError, 'route layer should emit error')
+          assert.ok(!routeError.ctx.handled,
+            'route layer is not an error handler — handled flag must be absent')
+
+          const handlerError = byName('throwingErrorHandler')
+          assert.ok(handlerError, 'error handler should emit its own error')
+          assert.equal(handlerError.ctx.handled, true,
+            'error handler\'s own error event must carry handled:true so APMs can classify the span correctly')
 
           done()
         })
@@ -578,11 +588,21 @@ describeTracing('TracingChannel', function () {
           if (err) return done(err)
 
           const errorEvents = events.filter(function (e) { return e.phase === 'error' })
-          const layerNames = errorEvents.map(function (e) { return e.ctx.layer.name })
+          const byName = function (name) {
+            return errorEvents.find(function (e) { return e.ctx.layer.name === name })
+          }
 
           assert.equal(errorEvents.length, 2, 'error should fire on both layers')
-          assert.ok(layerNames.includes('rejectingHandler'), 'route layer should emit error')
-          assert.ok(layerNames.includes('throwingErrorHandler'), 'error handler should emit its own error')
+
+          const routeError = byName('rejectingHandler')
+          assert.ok(routeError, 'route layer should emit error')
+          assert.ok(!routeError.ctx.handled,
+            'route layer is not an error handler — handled flag must be absent')
+
+          const handlerError = byName('throwingErrorHandler')
+          assert.ok(handlerError, 'error handler should emit its own error')
+          assert.equal(handlerError.ctx.handled, true,
+            'error handler\'s own error event must carry handled:true so APMs can classify the span correctly')
 
           done()
         })

--- a/test/tracing.js
+++ b/test/tracing.js
@@ -524,6 +524,33 @@ describeTracing('TracingChannel', function () {
         })
     })
 
+    it('should normalize a falsy rejection to the error the router forwards', function (done) {
+      const router = new Router()
+      const server = createServer(router)
+
+      dc.tracingChannel('express.router.request').subscribe(handlers)
+
+      router.get('/reject', async function rejectFalsy (req, res) {
+        return Promise.reject() // eslint-disable-line prefer-promise-reject-errors
+      })
+
+      request(server)
+        .get('/reject')
+        .expect(500, function (err) {
+          if (err) return done(err)
+
+          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          assert.equal(errorEvents.length, 1, 'should report the rejection once')
+
+          const reported = errorEvents[0].ctx.error
+          assert.ok(reported instanceof Error,
+            'a falsy rejection is reported as the Error the router forwards to next(), not the raw value')
+          assert.equal(reported.message, 'Rejected promise')
+
+          done()
+        })
+    })
+
     it('should emit error on route only when sync throw is recovered by a clean error handler', function (done) {
       const router = new Router()
       const server = createServer(router)

--- a/test/tracing.js
+++ b/test/tracing.js
@@ -867,10 +867,10 @@ describeTracing('TracingChannel', function () {
   })
 
   describe('event ordering', function () {
-    it('should emit start before asyncEnd', function (done) {
+    it('should emit only start and end for a synchronous handler', function (done) {
       const { router, server } = traced()
 
-      router.get('/order', function (req, res) {
+      router.get('/order', function syncHandler (req, res) {
         res.statusCode = 200
         res.end('ok')
       })
@@ -880,13 +880,35 @@ describeTracing('TracingChannel', function () {
         .expect(200, function (err) {
           if (err) return done(err)
 
-          const phases = events.map(function (e) { return e.phase })
-          const firstStart = phases.indexOf('start')
-          const lastAsyncEnd = phases.lastIndexOf('asyncEnd')
+          const phases = events.filter(byLayer('syncHandler')).map(function (e) { return e.phase })
+          assert.equal(phases.length, 2, 'a synchronous handler has no async phase')
+          assert.equal(phases[0], 'start')
+          assert.equal(phases[1], 'end')
+          assert.ok(phases.indexOf('asyncStart') < 0 && phases.indexOf('asyncEnd') < 0,
+            'a synchronous handler should not emit asyncStart/asyncEnd')
 
-          assert.ok(firstStart >= 0, 'should have start')
-          assert.ok(lastAsyncEnd >= 0, 'should have asyncEnd')
-          assert.ok(firstStart < lastAsyncEnd, 'start should come before asyncEnd')
+          done()
+        })
+    })
+
+    it('should emit start before asyncEnd for an asynchronous handler', function (done) {
+      const { router, server } = traced()
+
+      router.get('/order', async function asyncHandler (req, res) {
+        res.statusCode = 200
+        res.end('ok')
+      })
+
+      request(server)
+        .get('/order')
+        .expect(200, function (err) {
+          if (err) return done(err)
+
+          const phases = events.filter(byLayer('asyncHandler')).map(function (e) { return e.phase })
+          assert.ok(phases.indexOf('start') >= 0, 'should have start')
+          assert.ok(phases.indexOf('asyncEnd') >= 0, 'should have asyncEnd')
+          assert.ok(phases.indexOf('start') < phases.indexOf('asyncEnd'),
+            'start should come before asyncEnd')
 
           done()
         })

--- a/test/tracing.js
+++ b/test/tracing.js
@@ -324,7 +324,7 @@ describeTracing('TracingChannel', function () {
         })
     })
 
-    it('should not emit error for next("route") or next("router") control-flow sentinels', function (done) {
+    it('should not emit error for next("route") control-flow sentinel', function (done) {
       const router = new Router()
       const server = createServer(router)
 
@@ -347,6 +347,34 @@ describeTracing('TracingChannel', function () {
           const errorEvents = events.filter(function (e) { return e.phase === 'error' })
           assert.equal(errorEvents.length, 0,
             'next("route") is a control-flow sentinel, not an error — nothing should publish')
+
+          done()
+        })
+    })
+
+    it('should not emit error for next("router") control-flow sentinel', function (done) {
+      const router = new Router()
+      const server = createServer(router)
+
+      dc.tracingChannel('express:request').subscribe(handlers)
+
+      router.use(function ejectFromRouter (req, res, next) {
+        next('router')
+      })
+
+      router.get('/foo', function shouldNotRun (req, res) {
+        res.statusCode = 200
+        res.end('should not reach')
+      })
+
+      request(server)
+        .get('/foo')
+        .expect(404, function (err) {
+          if (err) return done(err)
+
+          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          assert.equal(errorEvents.length, 0,
+            'next("router") is a control-flow sentinel, not an error — nothing should publish')
 
           done()
         })

--- a/test/tracing.js
+++ b/test/tracing.js
@@ -1,0 +1,402 @@
+const { it, describe, beforeEach, afterEach } = require('mocha')
+const Router = require('..')
+const utils = require('./support/utils')
+
+const assert = utils.assert
+const createServer = utils.createServer
+const request = utils.request
+
+let dc
+let tracingChannel
+
+try {
+  dc = require('node:diagnostics_channel')
+  if (dc.tracingChannel) {
+    tracingChannel = dc.tracingChannel
+  }
+} catch {}
+
+const describeTracing = tracingChannel ? describe : describe.skip
+
+describeTracing('TracingChannel', function () {
+  let handlers
+  let events
+
+  beforeEach(function () {
+    events = []
+    handlers = {
+      start (ctx) { events.push({ phase: 'start', ctx }) },
+      end (ctx) { events.push({ phase: 'end', ctx }) },
+      asyncStart (ctx) { events.push({ phase: 'asyncStart', ctx }) },
+      asyncEnd (ctx) { events.push({ phase: 'asyncEnd', ctx }) },
+      error (ctx) { events.push({ phase: 'error', ctx }) }
+    }
+  })
+
+  afterEach(function () {
+    dc.tracingChannel('express:request').unsubscribe(handlers)
+  })
+
+  describe('when no subscribers', function () {
+    it('should not affect normal behavior', function (done) {
+      const router = new Router()
+      const server = createServer(router)
+
+      router.get('/foo', function (req, res) {
+        res.statusCode = 200
+        res.end('hello')
+      })
+
+      request(server)
+        .get('/foo')
+        .expect(200, 'hello', done)
+    })
+  })
+
+  describe('context shape', function () {
+    it('should provide req, res, and layer in context', function (done) {
+      const router = new Router()
+      const server = createServer(router)
+
+      dc.tracingChannel('express:request').subscribe(handlers)
+
+      router.use(function myMiddleware (req, res, next) {
+        next()
+      })
+
+      router.get('/foo', function (req, res) {
+        res.statusCode = 200
+        res.end('hello')
+      })
+
+      request(server)
+        .get('/foo')
+        .expect(200, function (err) {
+          if (err) return done(err)
+
+          const startEvents = events.filter(function (e) { return e.phase === 'start' })
+          const middlewareStart = startEvents.find(function (e) {
+            return e.ctx.layer && e.ctx.layer.name === 'myMiddleware'
+          })
+
+          assert.ok(middlewareStart, 'should have start event for myMiddleware')
+          assert.ok(middlewareStart.ctx.req, 'should have req')
+          assert.ok(middlewareStart.ctx.res, 'should have res')
+          assert.ok(middlewareStart.ctx.layer, 'should have layer')
+          assert.equal(middlewareStart.ctx.layer.name, 'myMiddleware')
+
+          done()
+        })
+    })
+
+    it('should have layer.name as <anonymous> for unnamed middleware', function (done) {
+      const router = new Router()
+      const server = createServer(router)
+
+      dc.tracingChannel('express:request').subscribe(handlers)
+
+      router.use(function (req, res, next) {
+        next()
+      })
+
+      router.get('/foo', function (req, res) {
+        res.statusCode = 200
+        res.end('hello')
+      })
+
+      request(server)
+        .get('/foo')
+        .expect(200, function (err) {
+          if (err) return done(err)
+
+          const startEvents = events.filter(function (e) { return e.phase === 'start' })
+          const anonMiddleware = startEvents.find(function (e) {
+            return e.ctx.layer && e.ctx.layer.name === '<anonymous>'
+          })
+
+          assert.ok(anonMiddleware, 'should have anonymous middleware event')
+
+          done()
+        })
+    })
+  })
+
+  describe('route handler tracing', function () {
+    it('should have req.route set for route handlers', function (done) {
+      const router = new Router()
+      const server = createServer(router)
+
+      dc.tracingChannel('express:request').subscribe(handlers)
+
+      router.get('/users/:id', function getUser (req, res) {
+        res.statusCode = 200
+        res.end('user')
+      })
+
+      request(server)
+        .get('/users/123')
+        .expect(200, function (err) {
+          if (err) return done(err)
+
+          const startEvents = events.filter(function (e) { return e.phase === 'start' })
+          const handlerStart = startEvents.find(function (e) {
+            return e.ctx.layer && e.ctx.layer.name === 'getUser'
+          })
+
+          assert.ok(handlerStart, 'should have start event for getUser')
+          assert.ok(handlerStart.ctx.req.route, 'should have req.route')
+          assert.equal(handlerStart.ctx.req.route.path, '/users/:id')
+
+          done()
+        })
+    })
+
+    it('should not trace the route dispatch wrapper', function (done) {
+      const router = new Router()
+      const server = createServer(router)
+
+      dc.tracingChannel('express:request').subscribe(handlers)
+
+      router.get('/foo', function myHandler (req, res) {
+        res.statusCode = 200
+        res.end('ok')
+      })
+
+      request(server)
+        .get('/foo')
+        .expect(200, function (err) {
+          if (err) return done(err)
+
+          const startEvents = events.filter(function (e) { return e.phase === 'start' })
+          const dispatchWrapper = startEvents.find(function (e) {
+            return e.ctx.layer && e.ctx.layer.name === 'handle'
+          })
+
+          assert.ok(!dispatchWrapper, 'should not have dispatch wrapper event')
+
+          done()
+        })
+    })
+  })
+
+  describe('error handler tracing', function () {
+    it('should trace error handlers (fn.length === 4)', function (done) {
+      const router = new Router()
+      const server = createServer(router)
+
+      dc.tracingChannel('express:request').subscribe(handlers)
+
+      router.get('/fail', function (req, res, next) {
+        next(new Error('boom'))
+      })
+
+      router.use(function myErrorHandler (err, req, res, next) { // eslint-disable-line no-unused-vars
+        res.statusCode = 500
+        res.end(err.message)
+      })
+
+      request(server)
+        .get('/fail')
+        .expect(500, 'boom', function (err) {
+          if (err) return done(err)
+
+          const startEvents = events.filter(function (e) { return e.phase === 'start' })
+          const errorHandlerStart = startEvents.find(function (e) {
+            return e.ctx.layer && e.ctx.layer.name === 'myErrorHandler'
+          })
+
+          assert.ok(errorHandlerStart, 'should have start event for error handler')
+          assert.equal(errorHandlerStart.ctx.layer.handle.length, 4)
+
+          done()
+        })
+    })
+  })
+
+  describe('error channel', function () {
+    it('should emit error when handler throws synchronously', function (done) {
+      const router = new Router()
+      const server = createServer(router)
+
+      dc.tracingChannel('express:request').subscribe(handlers)
+
+      router.get('/throw', function (req, res) {
+        throw new Error('sync boom')
+      })
+
+      request(server)
+        .get('/throw')
+        .expect(500, function (err) {
+          if (err) return done(err)
+
+          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          assert.ok(errorEvents.length > 0, 'should have error events')
+
+          const errorEvent = errorEvents.find(function (e) {
+            return e.ctx.error && e.ctx.error.message === 'sync boom'
+          })
+          assert.ok(errorEvent, 'should have error event with the thrown error')
+
+          done()
+        })
+    })
+
+    it('should emit error when async handler rejects', function (done) {
+      const router = new Router()
+      const server = createServer(router)
+
+      dc.tracingChannel('express:request').subscribe(handlers)
+
+      router.get('/reject', async function (req, res) {
+        throw new Error('async boom')
+      })
+
+      request(server)
+        .get('/reject')
+        .expect(500, function (err) {
+          if (err) return done(err)
+
+          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          assert.ok(errorEvents.length > 0, 'should have error events')
+
+          const errorEvent = errorEvents.find(function (e) {
+            return e.ctx.error && e.ctx.error.message === 'async boom'
+          })
+          assert.ok(errorEvent, 'should have error event with the rejected error')
+
+          done()
+        })
+    })
+  })
+
+  describe('async handlers', function () {
+    it('should trace async handlers that return promises', function (done) {
+      const router = new Router()
+      const server = createServer(router)
+
+      dc.tracingChannel('express:request').subscribe(handlers)
+
+      router.get('/async', function asyncHandler (req, res) {
+        return new Promise(function (resolve) {
+          setTimeout(function () {
+            res.statusCode = 200
+            res.end('async hello')
+            resolve()
+          }, 10)
+        })
+      })
+
+      request(server)
+        .get('/async')
+        .expect(200, 'async hello', function (err) {
+          if (err) return done(err)
+
+          const startEvents = events.filter(function (e) { return e.phase === 'start' })
+          const asyncEndEvents = events.filter(function (e) { return e.phase === 'asyncEnd' })
+
+          assert.ok(startEvents.length > 0, 'should have start events')
+          assert.ok(asyncEndEvents.length > 0, 'should have asyncEnd events')
+
+          done()
+        })
+    })
+  })
+
+  describe('nested routers', function () {
+    it('should trace middleware in nested routers', function (done) {
+      const router = new Router()
+      const nested = new Router()
+      const server = createServer(router)
+
+      dc.tracingChannel('express:request').subscribe(handlers)
+
+      nested.get('/bar', function nestedHandler (req, res) {
+        res.statusCode = 200
+        res.end('nested')
+      })
+
+      router.use('/foo', nested)
+
+      request(server)
+        .get('/foo/bar')
+        .expect(200, 'nested', function (err) {
+          if (err) return done(err)
+
+          const startEvents = events.filter(function (e) { return e.phase === 'start' })
+          const handlerEvent = startEvents.find(function (e) {
+            return e.ctx.layer && e.ctx.layer.name === 'nestedHandler'
+          })
+          assert.ok(handlerEvent, 'should have event from nested route handler')
+          assert.ok(handlerEvent.ctx.req.route, 'should have req.route')
+
+          done()
+        })
+    })
+  })
+
+  describe('event ordering', function () {
+    it('should emit start before asyncEnd', function (done) {
+      const router = new Router()
+      const server = createServer(router)
+
+      dc.tracingChannel('express:request').subscribe(handlers)
+
+      router.get('/order', function (req, res) {
+        res.statusCode = 200
+        res.end('ok')
+      })
+
+      request(server)
+        .get('/order')
+        .expect(200, function (err) {
+          if (err) return done(err)
+
+          const phases = events.map(function (e) { return e.phase })
+          const firstStart = phases.indexOf('start')
+          const lastAsyncEnd = phases.lastIndexOf('asyncEnd')
+
+          assert.ok(firstStart >= 0, 'should have start')
+          assert.ok(lastAsyncEnd >= 0, 'should have asyncEnd')
+          assert.ok(firstStart < lastAsyncEnd, 'start should come before asyncEnd')
+
+          done()
+        })
+    })
+  })
+
+  describe('multiple middleware', function () {
+    it('should emit events for each middleware in the chain', function (done) {
+      const router = new Router()
+      const server = createServer(router)
+
+      dc.tracingChannel('express:request').subscribe(handlers)
+
+      router.use(function first (req, res, next) {
+        next()
+      })
+
+      router.use(function second (req, res, next) {
+        next()
+      })
+
+      router.get('/multi', function handler (req, res) {
+        res.statusCode = 200
+        res.end('multi')
+      })
+
+      request(server)
+        .get('/multi')
+        .expect(200, function (err) {
+          if (err) return done(err)
+
+          const startEvents = events.filter(function (e) { return e.phase === 'start' })
+          const names = startEvents.map(function (e) { return e.ctx.layer.name })
+
+          assert.ok(names.indexOf('first') >= 0, 'should trace first middleware')
+          assert.ok(names.indexOf('second') >= 0, 'should trace second middleware')
+
+          done()
+        })
+    })
+  })
+})

--- a/test/tracing.js
+++ b/test/tracing.js
@@ -545,6 +545,34 @@ describeTracing('TracingChannel', function () {
         })
     })
 
+    it('should keep routing after a sync falsy throw, same as the untraced path', function (done) {
+      const router = new Router()
+      const server = createServer(router)
+
+      dc.tracingChannel(CHANNEL).subscribe(handlers)
+
+      router.get('/falsy', function throwsFalsy (req, res) {
+        throw undefined // eslint-disable-line no-throw-literal
+      })
+
+      router.get('/falsy', function continues (req, res) {
+        res.statusCode = 200
+        res.end('continued')
+      })
+
+      request(server)
+        .get('/falsy')
+        .expect(200, 'continued', function (err) {
+          if (err) return done(err)
+
+          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          assert.equal(errorEvents.length, 0,
+            'the untraced router treats a sync falsy throw as next(), so subscribing must not divert it to error handling')
+
+          done()
+        })
+    })
+
     it('should emit error on route only when sync throw is recovered by a clean error handler', function (done) {
       const router = new Router()
       const server = createServer(router)
@@ -894,6 +922,37 @@ describeTracing('TracingChannel', function () {
           const errorEvents = events.filter(function (e) { return e.phase === 'error' })
           assert.equal(errorEvents.length, 1,
             'forwarding the same error with next(err) must not re-report it')
+          assert.equal(errorEvents[0].ctx.layer.name, 'origin')
+
+          done()
+        })
+    })
+
+    it('should report next(err) once when an error handler rethrows it', function (done) {
+      const router = new Router()
+      const server = createServer(router)
+
+      dc.tracingChannel(CHANNEL).subscribe(handlers)
+
+      router.get('/fail', function origin (req, res, next) {
+        next(new Error('boom'))
+      })
+      router.use(function rethrowing (err, req, res, next) { // eslint-disable-line no-unused-vars
+        throw err
+      })
+      router.use(function recover (err, req, res, next) { // eslint-disable-line no-unused-vars
+        res.statusCode = 500
+        res.end(err.message)
+      })
+
+      request(server)
+        .get('/fail')
+        .expect(500, 'boom', function (err) {
+          if (err) return done(err)
+
+          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          assert.equal(errorEvents.length, 1,
+            'throw err and next(err) are equivalent to the router, so rethrowing the same error must not re-report it')
           assert.equal(errorEvents[0].ctx.layer.name, 'origin')
 
           done()

--- a/test/tracing.js
+++ b/test/tracing.js
@@ -178,7 +178,7 @@ describeTracing('TracingChannel', function () {
   })
 
   describe('error handler tracing', function () {
-    it('should trace error handlers (fn.length === 4) and mark their ctx as handled', function (done) {
+    it('should trace error handlers (fn.length === 4) and flag their ctx as errorHandler', function (done) {
       const { router, server } = traced()
 
       router.get('/fail', function failingHandler (req, res, next) {
@@ -201,8 +201,8 @@ describeTracing('TracingChannel', function () {
           const errorHandlerStart = errorHandlerEvents.find(byPhase('start'))
           assert.ok(errorHandlerStart, 'should have start event for error handler')
           assert.equal(errorHandlerStart.ctx.layer.handle.length, 4)
-          assert.equal(errorHandlerStart.ctx.handled, true,
-            'error handler ctx should be marked handled so APMs can dedup the origin error')
+          assert.equal(errorHandlerStart.ctx.errorHandler, true,
+            'error handler ctx should be flagged errorHandler so APMs can dedup the origin error')
           assert.ok(errorHandlerStart.ctx.error,
             'error handler ctx should expose the error it received')
 
@@ -212,8 +212,8 @@ describeTracing('TracingChannel', function () {
           const failingError = failingEvents.find(byPhase('error'))
           assert.ok(failingError, 'origin layer should emit error for next(err)')
           assert.equal(failingError.ctx.error.message, 'boom')
-          assert.ok(!failingError.ctx.handled,
-            'origin layer ctx is not the handler, so it should not be marked handled')
+          assert.ok(!failingError.ctx.errorHandler,
+            'origin layer is not an error handler, so it should not be flagged errorHandler')
 
           done()
         })
@@ -248,8 +248,8 @@ describeTracing('TracingChannel', function () {
             'recovering error handler itself did not throw, so it should not emit error')
 
           const errorHandlerStart = errorHandlerEvents.find(byPhase('start'))
-          assert.equal(errorHandlerStart.ctx.handled, true,
-            'error handler ctx is marked handled so APMs can dedup against the origin error')
+          assert.equal(errorHandlerStart.ctx.errorHandler, true,
+            'error handler ctx is flagged errorHandler so APMs can dedup against the origin error')
 
           const errorEvents = events.filter(byPhase('error'))
           assert.equal(errorEvents.length, 1,
@@ -608,13 +608,13 @@ describeTracing('TracingChannel', function () {
 
           const routeError = errorEvents.find(byLayer('throwingHandler'))
           assert.ok(routeError, 'route layer should emit error')
-          assert.ok(!routeError.ctx.handled,
-            'route layer is not an error handler, so handled flag must be absent')
+          assert.ok(!routeError.ctx.errorHandler,
+            'route layer is not an error handler, so errorHandler flag must be absent')
 
           const handlerError = errorEvents.find(byLayer('throwingErrorHandler'))
           assert.ok(handlerError, 'error handler should emit its own error')
-          assert.equal(handlerError.ctx.handled, true,
-            'error handler\'s own error event must carry handled:true so APMs can classify the span correctly')
+          assert.equal(handlerError.ctx.errorHandler, true,
+            'error handler\'s own error event must carry errorHandler:true so APMs can classify the span correctly')
 
           done()
         })
@@ -643,13 +643,13 @@ describeTracing('TracingChannel', function () {
 
           const routeError = errorEvents.find(byLayer('rejectingHandler'))
           assert.ok(routeError, 'route layer should emit error')
-          assert.ok(!routeError.ctx.handled,
-            'route layer is not an error handler, so handled flag must be absent')
+          assert.ok(!routeError.ctx.errorHandler,
+            'route layer is not an error handler, so errorHandler flag must be absent')
 
           const handlerError = errorEvents.find(byLayer('throwingErrorHandler'))
           assert.ok(handlerError, 'error handler should emit its own error')
-          assert.equal(handlerError.ctx.handled, true,
-            'error handler\'s own error event must carry handled:true so APMs can classify the span correctly')
+          assert.equal(handlerError.ctx.errorHandler, true,
+            'error handler\'s own error event must carry errorHandler:true so APMs can classify the span correctly')
 
           done()
         })

--- a/test/tracing.js
+++ b/test/tracing.js
@@ -211,6 +211,132 @@ describeTracing('TracingChannel', function () {
           done()
         })
     })
+
+    it('should not emit error on the originating layer when next(err) is recovered downstream', function (done) {
+      const router = new Router()
+      const server = createServer(router)
+
+      dc.tracingChannel('express:request').subscribe(handlers)
+
+      router.get('/fail', function failingHandler (req, res, next) {
+        next(new Error('boom'))
+      })
+
+      router.use(function myErrorHandler (err, req, res, next) { // eslint-disable-line no-unused-vars
+        res.statusCode = 500
+        res.end(err.message)
+      })
+
+      request(server)
+        .get('/fail')
+        .expect(500, 'boom', function (err) {
+          if (err) return done(err)
+
+          const byLayer = function (name) {
+            return function (e) { return e.ctx.layer && e.ctx.layer.name === name }
+          }
+
+          const failingEvents = events.filter(byLayer('failingHandler'))
+          const errorHandlerEvents = events.filter(byLayer('myErrorHandler'))
+
+          assert.ok(failingEvents.some(function (e) { return e.phase === 'start' }),
+            'originating layer should have a start event')
+          assert.ok(!failingEvents.some(function (e) { return e.phase === 'error' }),
+            'originating layer should not emit error — next(err) is normal control flow, not an exception')
+
+          assert.ok(errorHandlerEvents.some(function (e) { return e.phase === 'start' }),
+            'recovering error handler should have a start event')
+          assert.ok(!errorHandlerEvents.some(function (e) { return e.phase === 'error' }),
+            'recovering error handler should not emit error — it handled the error successfully')
+
+          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          assert.equal(errorEvents.length, 0,
+            'no error event should fire anywhere when an error is forwarded via next() and recovered downstream')
+
+          done()
+        })
+    })
+
+    it('should nest the error handler span inside the originating layer span', function (done) {
+      const router = new Router()
+      const server = createServer(router)
+
+      dc.tracingChannel('express:request').subscribe(handlers)
+
+      router.use(function firstMiddleware (req, res, next) {
+        next()
+      })
+
+      router.get('/fail', function failingHandler (req, res, next) {
+        next(new Error('boom'))
+      })
+
+      router.use(function myErrorHandler (err, req, res, next) { // eslint-disable-line no-unused-vars
+        res.statusCode = 500
+        res.end(err.message)
+      })
+
+      request(server)
+        .get('/fail')
+        .expect(500, 'boom', function (err) {
+          if (err) return done(err)
+
+          const syncEvents = events.filter(function (e) {
+            return e.phase === 'start' || e.phase === 'end'
+          }).map(function (e) {
+            return e.phase + ':' + (e.ctx.layer && e.ctx.layer.name)
+          })
+
+          const failingStart = syncEvents.indexOf('start:failingHandler')
+          const failingEnd = syncEvents.indexOf('end:failingHandler')
+          const errorHandlerStart = syncEvents.indexOf('start:myErrorHandler')
+          const errorHandlerEnd = syncEvents.indexOf('end:myErrorHandler')
+
+          assert.notEqual(failingStart, -1, 'failingHandler should have start')
+          assert.notEqual(errorHandlerStart, -1, 'myErrorHandler should have start')
+
+          assert.ok(failingStart < errorHandlerStart,
+            'failing layer start should come before error handler start')
+          assert.ok(errorHandlerStart < errorHandlerEnd,
+            'error handler start should come before its own end')
+          assert.ok(errorHandlerEnd < failingEnd,
+            'error handler end should come before failing layer end — nesting contract: the error handler that runs via next(err) is nested inside the layer that triggered it, letting APMs attribute the error to the correct parent span')
+
+          done()
+        })
+    })
+
+    it('should not emit error on the originating layer when next(err) is unhandled', function (done) {
+      const router = new Router()
+      const server = createServer(router)
+
+      dc.tracingChannel('express:request').subscribe(handlers)
+
+      router.get('/fail', function failingHandler (req, res, next) {
+        next(new Error('unhandled boom'))
+      })
+
+      request(server)
+        .get('/fail')
+        .expect(500, function (err) {
+          if (err) return done(err)
+
+          const failingEvents = events.filter(function (e) {
+            return e.ctx.layer && e.ctx.layer.name === 'failingHandler'
+          })
+
+          assert.ok(failingEvents.some(function (e) { return e.phase === 'start' }),
+            'originating layer should have a start event')
+          assert.ok(!failingEvents.some(function (e) { return e.phase === 'error' }),
+            'originating layer should not emit error even when no error handler exists — next(err) is not an exception from tracePromise\'s perspective')
+
+          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          assert.equal(errorEvents.length, 0,
+            'no error event fires on the channel when errors are forwarded via next(); APMs relying on this channel cannot detect next(err) errors')
+
+          done()
+        })
+    })
   })
 
   describe('error channel', function () {
@@ -263,6 +389,124 @@ describeTracing('TracingChannel', function () {
             return e.ctx.error && e.ctx.error.message === 'async boom'
           })
           assert.ok(errorEvent, 'should have error event with the rejected error')
+
+          done()
+        })
+    })
+
+    it('should emit error on route only when sync throw is recovered by a clean error handler', function (done) {
+      const router = new Router()
+      const server = createServer(router)
+
+      dc.tracingChannel('express:request').subscribe(handlers)
+
+      router.get('/throw', function throwingHandler (req, res) {
+        throw new Error('sync boom')
+      })
+
+      router.use(function cleanErrorHandler (err, req, res, next) { // eslint-disable-line no-unused-vars
+        res.statusCode = 500
+        res.end(err.message)
+      })
+
+      request(server)
+        .get('/throw')
+        .expect(500, 'sync boom', function (err) {
+          if (err) return done(err)
+
+          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          assert.equal(errorEvents.length, 1, 'exactly one error event should fire')
+          assert.equal(errorEvents[0].ctx.layer.name, 'throwingHandler',
+            'error event should belong to the throwing route layer')
+
+          done()
+        })
+    })
+
+    it('should emit error on route only when async reject is recovered by a clean error handler', function (done) {
+      const router = new Router()
+      const server = createServer(router)
+
+      dc.tracingChannel('express:request').subscribe(handlers)
+
+      router.get('/reject', async function rejectingHandler (req, res) {
+        throw new Error('async boom')
+      })
+
+      router.use(function cleanErrorHandler (err, req, res, next) { // eslint-disable-line no-unused-vars
+        res.statusCode = 500
+        res.end(err.message)
+      })
+
+      request(server)
+        .get('/reject')
+        .expect(500, 'async boom', function (err) {
+          if (err) return done(err)
+
+          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          assert.equal(errorEvents.length, 1, 'exactly one error event should fire')
+          assert.equal(errorEvents[0].ctx.layer.name, 'rejectingHandler',
+            'error event should belong to the rejecting route layer')
+
+          done()
+        })
+    })
+
+    it('should emit error on both layers when sync throw is followed by a throwing error handler', function (done) {
+      const router = new Router()
+      const server = createServer(router)
+
+      dc.tracingChannel('express:request').subscribe(handlers)
+
+      router.get('/throw', function throwingHandler (req, res) {
+        throw new Error('sync boom')
+      })
+
+      router.use(function throwingErrorHandler (err, req, res, next) { // eslint-disable-line no-unused-vars
+        throw new Error('handler boom')
+      })
+
+      request(server)
+        .get('/throw')
+        .expect(500, function (err) {
+          if (err) return done(err)
+
+          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          const layerNames = errorEvents.map(function (e) { return e.ctx.layer.name })
+
+          assert.equal(errorEvents.length, 2, 'error should fire on both layers')
+          assert.ok(layerNames.includes('throwingHandler'), 'route layer should emit error')
+          assert.ok(layerNames.includes('throwingErrorHandler'), 'error handler should emit its own error')
+
+          done()
+        })
+    })
+
+    it('should emit error on both layers when async reject is followed by a throwing error handler', function (done) {
+      const router = new Router()
+      const server = createServer(router)
+
+      dc.tracingChannel('express:request').subscribe(handlers)
+
+      router.get('/reject', async function rejectingHandler (req, res) {
+        throw new Error('async boom')
+      })
+
+      router.use(function throwingErrorHandler (err, req, res, next) { // eslint-disable-line no-unused-vars
+        throw new Error('handler boom')
+      })
+
+      request(server)
+        .get('/reject')
+        .expect(500, function (err) {
+          if (err) return done(err)
+
+          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          const layerNames = errorEvents.map(function (e) { return e.ctx.layer.name })
+
+          assert.equal(errorEvents.length, 2, 'error should fire on both layers')
+          assert.ok(layerNames.includes('rejectingHandler'), 'route layer should emit error')
+          assert.ok(layerNames.includes('throwingErrorHandler'), 'error handler should emit its own error')
 
           done()
         })

--- a/test/tracing.js
+++ b/test/tracing.js
@@ -34,7 +34,7 @@ describeTracing('TracingChannel', function () {
   })
 
   afterEach(function () {
-    dc.tracingChannel('pillarjs.router.request').unsubscribe(handlers)
+    dc.tracingChannel('express.router.request').unsubscribe(handlers)
   })
 
   describe('when no subscribers', function () {
@@ -58,7 +58,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
+      dc.tracingChannel('express.router.request').subscribe(handlers)
 
       router.use(function myMiddleware (req, res, next) {
         next()
@@ -93,7 +93,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
+      dc.tracingChannel('express.router.request').subscribe(handlers)
 
       router.use(function (req, res, next) {
         next()
@@ -126,7 +126,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
+      dc.tracingChannel('express.router.request').subscribe(handlers)
 
       router.get('/users/:id', function getUser (req, res) {
         res.statusCode = 200
@@ -155,7 +155,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
+      dc.tracingChannel('express.router.request').subscribe(handlers)
 
       router.get('/foo', function myHandler (req, res) {
         res.statusCode = 200
@@ -184,7 +184,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
+      dc.tracingChannel('express.router.request').subscribe(handlers)
 
       router.get('/fail', function failingHandler (req, res, next) {
         next(new Error('boom'))
@@ -232,7 +232,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
+      dc.tracingChannel('express.router.request').subscribe(handlers)
 
       router.get('/fail', function failingHandler (req, res, next) {
         next(new Error('boom'))
@@ -279,7 +279,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
+      dc.tracingChannel('express.router.request').subscribe(handlers)
 
       router.use(function firstMiddleware (req, res, next) {
         next()
@@ -328,7 +328,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
+      dc.tracingChannel('express.router.request').subscribe(handlers)
 
       router.get('/skip', function skipToNextRoute (req, res, next) {
         next('route')
@@ -356,7 +356,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
+      dc.tracingChannel('express.router.request').subscribe(handlers)
 
       router.use(function ejectFromRouter (req, res, next) {
         next('router')
@@ -384,7 +384,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
+      dc.tracingChannel('express.router.request').subscribe(handlers)
 
       router.get('/fail', function failingHandler (req, res, next) {
         next(new Error('unhandled boom'))
@@ -418,7 +418,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
+      dc.tracingChannel('express.router.request').subscribe(handlers)
 
       router.get('/throw', function (req, res) {
         throw new Error('sync boom')
@@ -445,7 +445,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
+      dc.tracingChannel('express.router.request').subscribe(handlers)
 
       router.get('/reject', async function (req, res) {
         throw new Error('async boom')
@@ -472,7 +472,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
+      dc.tracingChannel('express.router.request').subscribe(handlers)
 
       router.get('/throw', function throwingHandler (req, res) {
         throw new Error('sync boom')
@@ -501,7 +501,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
+      dc.tracingChannel('express.router.request').subscribe(handlers)
 
       router.get('/reject', async function rejectingHandler (req, res) {
         throw new Error('async boom')
@@ -530,7 +530,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
+      dc.tracingChannel('express.router.request').subscribe(handlers)
 
       router.get('/throw', function throwingHandler (req, res) {
         throw new Error('sync boom')
@@ -571,7 +571,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
+      dc.tracingChannel('express.router.request').subscribe(handlers)
 
       router.get('/reject', async function rejectingHandler (req, res) {
         throw new Error('async boom')
@@ -614,7 +614,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
+      dc.tracingChannel('express.router.request').subscribe(handlers)
 
       router.get('/async', function asyncHandler (req, res) {
         return new Promise(function (resolve) {
@@ -648,7 +648,7 @@ describeTracing('TracingChannel', function () {
       const nested = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
+      dc.tracingChannel('express.router.request').subscribe(handlers)
 
       nested.get('/bar', function nestedHandler (req, res) {
         res.statusCode = 200
@@ -679,7 +679,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
+      dc.tracingChannel('express.router.request').subscribe(handlers)
 
       router.get('/order', function (req, res) {
         res.statusCode = 200
@@ -709,7 +709,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
+      dc.tracingChannel('express.router.request').subscribe(handlers)
 
       router.use(function first (req, res, next) {
         next()

--- a/test/tracing.js
+++ b/test/tracing.js
@@ -34,7 +34,7 @@ describeTracing('TracingChannel', function () {
   })
 
   afterEach(function () {
-    dc.tracingChannel('express:request').unsubscribe(handlers)
+    dc.tracingChannel('pillarjs.router.request').unsubscribe(handlers)
   })
 
   describe('when no subscribers', function () {
@@ -58,7 +58,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express:request').subscribe(handlers)
+      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
 
       router.use(function myMiddleware (req, res, next) {
         next()
@@ -93,7 +93,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express:request').subscribe(handlers)
+      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
 
       router.use(function (req, res, next) {
         next()
@@ -126,7 +126,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express:request').subscribe(handlers)
+      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
 
       router.get('/users/:id', function getUser (req, res) {
         res.statusCode = 200
@@ -155,7 +155,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express:request').subscribe(handlers)
+      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
 
       router.get('/foo', function myHandler (req, res) {
         res.statusCode = 200
@@ -184,7 +184,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express:request').subscribe(handlers)
+      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
 
       router.get('/fail', function failingHandler (req, res, next) {
         next(new Error('boom'))
@@ -232,7 +232,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express:request').subscribe(handlers)
+      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
 
       router.get('/fail', function failingHandler (req, res, next) {
         next(new Error('boom'))
@@ -279,7 +279,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express:request').subscribe(handlers)
+      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
 
       router.use(function firstMiddleware (req, res, next) {
         next()
@@ -328,7 +328,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express:request').subscribe(handlers)
+      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
 
       router.get('/skip', function skipToNextRoute (req, res, next) {
         next('route')
@@ -356,7 +356,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express:request').subscribe(handlers)
+      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
 
       router.use(function ejectFromRouter (req, res, next) {
         next('router')
@@ -384,7 +384,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express:request').subscribe(handlers)
+      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
 
       router.get('/fail', function failingHandler (req, res, next) {
         next(new Error('unhandled boom'))
@@ -418,7 +418,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express:request').subscribe(handlers)
+      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
 
       router.get('/throw', function (req, res) {
         throw new Error('sync boom')
@@ -445,7 +445,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express:request').subscribe(handlers)
+      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
 
       router.get('/reject', async function (req, res) {
         throw new Error('async boom')
@@ -472,7 +472,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express:request').subscribe(handlers)
+      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
 
       router.get('/throw', function throwingHandler (req, res) {
         throw new Error('sync boom')
@@ -501,7 +501,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express:request').subscribe(handlers)
+      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
 
       router.get('/reject', async function rejectingHandler (req, res) {
         throw new Error('async boom')
@@ -530,7 +530,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express:request').subscribe(handlers)
+      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
 
       router.get('/throw', function throwingHandler (req, res) {
         throw new Error('sync boom')
@@ -571,7 +571,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express:request').subscribe(handlers)
+      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
 
       router.get('/reject', async function rejectingHandler (req, res) {
         throw new Error('async boom')
@@ -614,7 +614,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express:request').subscribe(handlers)
+      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
 
       router.get('/async', function asyncHandler (req, res) {
         return new Promise(function (resolve) {
@@ -648,7 +648,7 @@ describeTracing('TracingChannel', function () {
       const nested = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express:request').subscribe(handlers)
+      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
 
       nested.get('/bar', function nestedHandler (req, res) {
         res.statusCode = 200
@@ -679,7 +679,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express:request').subscribe(handlers)
+      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
 
       router.get('/order', function (req, res) {
         res.statusCode = 200
@@ -709,7 +709,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express:request').subscribe(handlers)
+      dc.tracingChannel('pillarjs.router.request').subscribe(handlers)
 
       router.use(function first (req, res, next) {
         next()

--- a/test/tracing.js
+++ b/test/tracing.js
@@ -39,6 +39,14 @@ describeTracing('TracingChannel', function () {
     dc.tracingChannel(CHANNEL).unsubscribe(handlers)
   })
 
+  // Build a router and server with the tracing handlers subscribed.
+  function traced () {
+    const router = new Router()
+    const server = createServer(router)
+    dc.tracingChannel(CHANNEL).subscribe(handlers)
+    return { router, server }
+  }
+
   describe('when no subscribers', function () {
     it('should not affect normal behavior', function (done) {
       const router = new Router()
@@ -57,10 +65,7 @@ describeTracing('TracingChannel', function () {
 
   describe('context shape', function () {
     it('should provide req, res, and layer in context', function (done) {
-      const router = new Router()
-      const server = createServer(router)
-
-      dc.tracingChannel(CHANNEL).subscribe(handlers)
+      const { router, server } = traced()
 
       router.use(function myMiddleware (req, res, next) {
         next()
@@ -76,7 +81,7 @@ describeTracing('TracingChannel', function () {
         .expect(200, function (err) {
           if (err) return done(err)
 
-          const startEvents = events.filter(function (e) { return e.phase === 'start' })
+          const startEvents = events.filter(byPhase('start'))
           const middlewareStart = startEvents.find(function (e) {
             return e.ctx.layer && e.ctx.layer.name === 'myMiddleware'
           })
@@ -92,10 +97,7 @@ describeTracing('TracingChannel', function () {
     })
 
     it('should have layer.name as <anonymous> for unnamed middleware', function (done) {
-      const router = new Router()
-      const server = createServer(router)
-
-      dc.tracingChannel(CHANNEL).subscribe(handlers)
+      const { router, server } = traced()
 
       router.use(function (req, res, next) {
         next()
@@ -111,7 +113,7 @@ describeTracing('TracingChannel', function () {
         .expect(200, function (err) {
           if (err) return done(err)
 
-          const startEvents = events.filter(function (e) { return e.phase === 'start' })
+          const startEvents = events.filter(byPhase('start'))
           const anonMiddleware = startEvents.find(function (e) {
             return e.ctx.layer && e.ctx.layer.name === '<anonymous>'
           })
@@ -125,10 +127,7 @@ describeTracing('TracingChannel', function () {
 
   describe('route handler tracing', function () {
     it('should have req.route set for route handlers', function (done) {
-      const router = new Router()
-      const server = createServer(router)
-
-      dc.tracingChannel(CHANNEL).subscribe(handlers)
+      const { router, server } = traced()
 
       router.get('/users/:id', function getUser (req, res) {
         res.statusCode = 200
@@ -140,7 +139,7 @@ describeTracing('TracingChannel', function () {
         .expect(200, function (err) {
           if (err) return done(err)
 
-          const startEvents = events.filter(function (e) { return e.phase === 'start' })
+          const startEvents = events.filter(byPhase('start'))
           const handlerStart = startEvents.find(function (e) {
             return e.ctx.layer && e.ctx.layer.name === 'getUser'
           })
@@ -154,10 +153,7 @@ describeTracing('TracingChannel', function () {
     })
 
     it('should not trace the route dispatch wrapper', function (done) {
-      const router = new Router()
-      const server = createServer(router)
-
-      dc.tracingChannel(CHANNEL).subscribe(handlers)
+      const { router, server } = traced()
 
       router.get('/foo', function myHandler (req, res) {
         res.statusCode = 200
@@ -169,7 +165,7 @@ describeTracing('TracingChannel', function () {
         .expect(200, function (err) {
           if (err) return done(err)
 
-          const startEvents = events.filter(function (e) { return e.phase === 'start' })
+          const startEvents = events.filter(byPhase('start'))
           const dispatchWrapper = startEvents.find(function (e) {
             return e.ctx.layer && e.ctx.layer.name === 'handle'
           })
@@ -183,10 +179,7 @@ describeTracing('TracingChannel', function () {
 
   describe('error handler tracing', function () {
     it('should trace error handlers (fn.length === 4) and mark their ctx as handled', function (done) {
-      const router = new Router()
-      const server = createServer(router)
-
-      dc.tracingChannel(CHANNEL).subscribe(handlers)
+      const { router, server } = traced()
 
       router.get('/fail', function failingHandler (req, res, next) {
         next(new Error('boom'))
@@ -205,7 +198,7 @@ describeTracing('TracingChannel', function () {
           const failingEvents = events.filter(byLayer('failingHandler'))
           const errorHandlerEvents = events.filter(byLayer('myErrorHandler'))
 
-          const errorHandlerStart = errorHandlerEvents.find(function (e) { return e.phase === 'start' })
+          const errorHandlerStart = errorHandlerEvents.find(byPhase('start'))
           assert.ok(errorHandlerStart, 'should have start event for error handler')
           assert.equal(errorHandlerStart.ctx.layer.handle.length, 4)
           assert.equal(errorHandlerStart.ctx.handled, true,
@@ -213,10 +206,10 @@ describeTracing('TracingChannel', function () {
           assert.ok(errorHandlerStart.ctx.error,
             'error handler ctx should expose the error it received')
 
-          assert.ok(!errorHandlerEvents.some(function (e) { return e.phase === 'error' }),
+          assert.ok(!errorHandlerEvents.some(byPhase('error')),
             'error handler itself did not throw, so it should not emit error')
 
-          const failingError = failingEvents.find(function (e) { return e.phase === 'error' })
+          const failingError = failingEvents.find(byPhase('error'))
           assert.ok(failingError, 'origin layer should emit error for next(err)')
           assert.equal(failingError.ctx.error.message, 'boom')
           assert.ok(!failingError.ctx.handled,
@@ -227,10 +220,7 @@ describeTracing('TracingChannel', function () {
     })
 
     it('should emit error on originating layer when next(err) is recovered downstream', function (done) {
-      const router = new Router()
-      const server = createServer(router)
-
-      dc.tracingChannel(CHANNEL).subscribe(handlers)
+      const { router, server } = traced()
 
       router.get('/fail', function failingHandler (req, res, next) {
         next(new Error('boom'))
@@ -249,19 +239,19 @@ describeTracing('TracingChannel', function () {
           const failingEvents = events.filter(byLayer('failingHandler'))
           const errorHandlerEvents = events.filter(byLayer('myErrorHandler'))
 
-          const failingError = failingEvents.find(function (e) { return e.phase === 'error' })
+          const failingError = failingEvents.find(byPhase('error'))
           assert.ok(failingError,
             'originating layer should emit error, since unhandled-at-origin is always observable')
           assert.equal(failingError.ctx.error.message, 'boom')
 
-          assert.ok(!errorHandlerEvents.some(function (e) { return e.phase === 'error' }),
+          assert.ok(!errorHandlerEvents.some(byPhase('error')),
             'recovering error handler itself did not throw, so it should not emit error')
 
-          const errorHandlerStart = errorHandlerEvents.find(function (e) { return e.phase === 'start' })
+          const errorHandlerStart = errorHandlerEvents.find(byPhase('start'))
           assert.equal(errorHandlerStart.ctx.handled, true,
             'error handler ctx is marked handled so APMs can dedup against the origin error')
 
-          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          const errorEvents = events.filter(byPhase('error'))
           assert.equal(errorEvents.length, 1,
             'exactly one error event fires, on the origin layer that called next(err)')
 
@@ -270,10 +260,7 @@ describeTracing('TracingChannel', function () {
     })
 
     it('should nest the error handler span inside the originating layer span', function (done) {
-      const router = new Router()
-      const server = createServer(router)
-
-      dc.tracingChannel(CHANNEL).subscribe(handlers)
+      const { router, server } = traced()
 
       router.use(function firstMiddleware (req, res, next) {
         next()
@@ -319,10 +306,7 @@ describeTracing('TracingChannel', function () {
     })
 
     it('should not emit error for next("route") routing signal', function (done) {
-      const router = new Router()
-      const server = createServer(router)
-
-      dc.tracingChannel(CHANNEL).subscribe(handlers)
+      const { router, server } = traced()
 
       router.get('/skip', function skipToNextRoute (req, res, next) {
         next('route')
@@ -338,7 +322,7 @@ describeTracing('TracingChannel', function () {
         .expect(200, 'skipped', function (err) {
           if (err) return done(err)
 
-          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          const errorEvents = events.filter(byPhase('error'))
           assert.equal(errorEvents.length, 0,
             'next("route") is a routing signal, not an error, so nothing should publish')
 
@@ -347,10 +331,7 @@ describeTracing('TracingChannel', function () {
     })
 
     it('should not emit error for next("router") routing signal', function (done) {
-      const router = new Router()
-      const server = createServer(router)
-
-      dc.tracingChannel(CHANNEL).subscribe(handlers)
+      const { router, server } = traced()
 
       router.use(function ejectFromRouter (req, res, next) {
         next('router')
@@ -366,7 +347,7 @@ describeTracing('TracingChannel', function () {
         .expect(404, function (err) {
           if (err) return done(err)
 
-          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          const errorEvents = events.filter(byPhase('error'))
           assert.equal(errorEvents.length, 0,
             'next("router") is a routing signal, not an error, so nothing should publish')
 
@@ -375,10 +356,7 @@ describeTracing('TracingChannel', function () {
     })
 
     it('should not emit error when a handler throws the "route" routing signal', function (done) {
-      const router = new Router()
-      const server = createServer(router)
-
-      dc.tracingChannel(CHANNEL).subscribe(handlers)
+      const { router, server } = traced()
 
       router.get('/skip', function throwRoute (req, res) {
         throw 'route' // eslint-disable-line no-throw-literal
@@ -394,7 +372,7 @@ describeTracing('TracingChannel', function () {
         .expect(200, 'skipped', function (err) {
           if (err) return done(err)
 
-          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          const errorEvents = events.filter(byPhase('error'))
           assert.equal(errorEvents.length, 0,
             'a thrown "route" routing signal is not an error, so nothing should publish')
 
@@ -403,10 +381,7 @@ describeTracing('TracingChannel', function () {
     })
 
     it('should not emit error when a handler throws the "router" routing signal', function (done) {
-      const router = new Router()
-      const server = createServer(router)
-
-      dc.tracingChannel(CHANNEL).subscribe(handlers)
+      const { router, server } = traced()
 
       router.use(function throwRouter (req, res) {
         throw 'router' // eslint-disable-line no-throw-literal
@@ -422,7 +397,7 @@ describeTracing('TracingChannel', function () {
         .expect(404, function (err) {
           if (err) return done(err)
 
-          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          const errorEvents = events.filter(byPhase('error'))
           assert.equal(errorEvents.length, 0,
             'a thrown "router" routing signal is not an error, so nothing should publish')
 
@@ -431,10 +406,7 @@ describeTracing('TracingChannel', function () {
     })
 
     it('should emit error on originating layer when next(err) is unhandled', function (done) {
-      const router = new Router()
-      const server = createServer(router)
-
-      dc.tracingChannel(CHANNEL).subscribe(handlers)
+      const { router, server } = traced()
 
       router.get('/fail', function failingHandler (req, res, next) {
         next(new Error('unhandled boom'))
@@ -449,12 +421,12 @@ describeTracing('TracingChannel', function () {
             return e.ctx.layer && e.ctx.layer.name === 'failingHandler'
           })
 
-          const failingError = failingEvents.find(function (e) { return e.phase === 'error' })
+          const failingError = failingEvents.find(byPhase('error'))
           assert.ok(failingError,
             'unhandled next(err) must be observable on the origin layer')
           assert.equal(failingError.ctx.error.message, 'unhandled boom')
 
-          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          const errorEvents = events.filter(byPhase('error'))
           assert.equal(errorEvents.length, 1,
             'exactly one error event fires, on the origin layer that called next(err)')
 
@@ -465,10 +437,7 @@ describeTracing('TracingChannel', function () {
 
   describe('error channel', function () {
     it('should emit error when handler throws synchronously', function (done) {
-      const router = new Router()
-      const server = createServer(router)
-
-      dc.tracingChannel(CHANNEL).subscribe(handlers)
+      const { router, server } = traced()
 
       router.get('/throw', function (req, res) {
         throw new Error('sync boom')
@@ -479,7 +448,7 @@ describeTracing('TracingChannel', function () {
         .expect(500, function (err) {
           if (err) return done(err)
 
-          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          const errorEvents = events.filter(byPhase('error'))
           assert.ok(errorEvents.length > 0, 'should have error events')
 
           const errorEvent = errorEvents.find(function (e) {
@@ -492,10 +461,7 @@ describeTracing('TracingChannel', function () {
     })
 
     it('should emit error when async handler rejects', function (done) {
-      const router = new Router()
-      const server = createServer(router)
-
-      dc.tracingChannel(CHANNEL).subscribe(handlers)
+      const { router, server } = traced()
 
       router.get('/reject', async function (req, res) {
         throw new Error('async boom')
@@ -506,7 +472,7 @@ describeTracing('TracingChannel', function () {
         .expect(500, function (err) {
           if (err) return done(err)
 
-          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          const errorEvents = events.filter(byPhase('error'))
           assert.ok(errorEvents.length > 0, 'should have error events')
 
           const errorEvent = errorEvents.find(function (e) {
@@ -519,10 +485,7 @@ describeTracing('TracingChannel', function () {
     })
 
     it('should normalize a falsy rejection to the error the router forwards', function (done) {
-      const router = new Router()
-      const server = createServer(router)
-
-      dc.tracingChannel(CHANNEL).subscribe(handlers)
+      const { router, server } = traced()
 
       router.get('/reject', async function rejectFalsy (req, res) {
         return Promise.reject() // eslint-disable-line prefer-promise-reject-errors
@@ -533,7 +496,7 @@ describeTracing('TracingChannel', function () {
         .expect(500, function (err) {
           if (err) return done(err)
 
-          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          const errorEvents = events.filter(byPhase('error'))
           assert.equal(errorEvents.length, 1, 'should report the rejection once')
 
           const reported = errorEvents[0].ctx.error
@@ -546,10 +509,7 @@ describeTracing('TracingChannel', function () {
     })
 
     it('should keep routing after a sync falsy throw, same as the untraced path', function (done) {
-      const router = new Router()
-      const server = createServer(router)
-
-      dc.tracingChannel(CHANNEL).subscribe(handlers)
+      const { router, server } = traced()
 
       router.get('/falsy', function throwsFalsy (req, res) {
         throw undefined // eslint-disable-line no-throw-literal
@@ -565,7 +525,7 @@ describeTracing('TracingChannel', function () {
         .expect(200, 'continued', function (err) {
           if (err) return done(err)
 
-          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          const errorEvents = events.filter(byPhase('error'))
           assert.equal(errorEvents.length, 0,
             'the untraced router treats a sync falsy throw as next(), so subscribing must not divert it to error handling')
 
@@ -574,10 +534,7 @@ describeTracing('TracingChannel', function () {
     })
 
     it('should emit error on route only when sync throw is recovered by a clean error handler', function (done) {
-      const router = new Router()
-      const server = createServer(router)
-
-      dc.tracingChannel(CHANNEL).subscribe(handlers)
+      const { router, server } = traced()
 
       router.get('/throw', function throwingHandler (req, res) {
         throw new Error('sync boom')
@@ -593,7 +550,7 @@ describeTracing('TracingChannel', function () {
         .expect(500, 'sync boom', function (err) {
           if (err) return done(err)
 
-          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          const errorEvents = events.filter(byPhase('error'))
           assert.equal(errorEvents.length, 1, 'exactly one error event should fire')
           assert.equal(errorEvents[0].ctx.layer.name, 'throwingHandler',
             'error event should belong to the throwing route layer')
@@ -603,10 +560,7 @@ describeTracing('TracingChannel', function () {
     })
 
     it('should emit error on route only when async reject is recovered by a clean error handler', function (done) {
-      const router = new Router()
-      const server = createServer(router)
-
-      dc.tracingChannel(CHANNEL).subscribe(handlers)
+      const { router, server } = traced()
 
       router.get('/reject', async function rejectingHandler (req, res) {
         throw new Error('async boom')
@@ -622,7 +576,7 @@ describeTracing('TracingChannel', function () {
         .expect(500, 'async boom', function (err) {
           if (err) return done(err)
 
-          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          const errorEvents = events.filter(byPhase('error'))
           assert.equal(errorEvents.length, 1, 'exactly one error event should fire')
           assert.equal(errorEvents[0].ctx.layer.name, 'rejectingHandler',
             'error event should belong to the rejecting route layer')
@@ -632,10 +586,7 @@ describeTracing('TracingChannel', function () {
     })
 
     it('should emit error on both layers when sync throw is followed by a throwing error handler', function (done) {
-      const router = new Router()
-      const server = createServer(router)
-
-      dc.tracingChannel(CHANNEL).subscribe(handlers)
+      const { router, server } = traced()
 
       router.get('/throw', function throwingHandler (req, res) {
         throw new Error('sync boom')
@@ -651,7 +602,7 @@ describeTracing('TracingChannel', function () {
         .expect(500, function (err) {
           if (err) return done(err)
 
-          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          const errorEvents = events.filter(byPhase('error'))
 
           assert.equal(errorEvents.length, 2, 'error should fire on both layers')
 
@@ -670,10 +621,7 @@ describeTracing('TracingChannel', function () {
     })
 
     it('should emit error on both layers when async reject is followed by a throwing error handler', function (done) {
-      const router = new Router()
-      const server = createServer(router)
-
-      dc.tracingChannel(CHANNEL).subscribe(handlers)
+      const { router, server } = traced()
 
       router.get('/reject', async function rejectingHandler (req, res) {
         throw new Error('async boom')
@@ -689,7 +637,7 @@ describeTracing('TracingChannel', function () {
         .expect(500, function (err) {
           if (err) return done(err)
 
-          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          const errorEvents = events.filter(byPhase('error'))
 
           assert.equal(errorEvents.length, 2, 'error should fire on both layers')
 
@@ -710,10 +658,7 @@ describeTracing('TracingChannel', function () {
 
   describe('async handlers', function () {
     it('should trace async handlers that return promises', function (done) {
-      const router = new Router()
-      const server = createServer(router)
-
-      dc.tracingChannel(CHANNEL).subscribe(handlers)
+      const { router, server } = traced()
 
       router.get('/async', function asyncHandler (req, res) {
         return new Promise(function (resolve) {
@@ -730,8 +675,8 @@ describeTracing('TracingChannel', function () {
         .expect(200, 'async hello', function (err) {
           if (err) return done(err)
 
-          const startEvents = events.filter(function (e) { return e.phase === 'start' })
-          const asyncEndEvents = events.filter(function (e) { return e.phase === 'asyncEnd' })
+          const startEvents = events.filter(byPhase('start'))
+          const asyncEndEvents = events.filter(byPhase('asyncEnd'))
 
           assert.ok(startEvents.length > 0, 'should have start events')
           assert.ok(asyncEndEvents.length > 0, 'should have asyncEnd events')
@@ -743,11 +688,8 @@ describeTracing('TracingChannel', function () {
 
   describe('nested routers', function () {
     it('should trace middleware in nested routers', function (done) {
-      const router = new Router()
+      const { router, server } = traced()
       const nested = new Router()
-      const server = createServer(router)
-
-      dc.tracingChannel(CHANNEL).subscribe(handlers)
 
       nested.get('/bar', function nestedHandler (req, res) {
         res.statusCode = 200
@@ -761,7 +703,7 @@ describeTracing('TracingChannel', function () {
         .expect(200, 'nested', function (err) {
           if (err) return done(err)
 
-          const startEvents = events.filter(function (e) { return e.phase === 'start' })
+          const startEvents = events.filter(byPhase('start'))
           const handlerEvent = startEvents.find(function (e) {
             return e.ctx.layer && e.ctx.layer.name === 'nestedHandler'
           })
@@ -775,27 +717,21 @@ describeTracing('TracingChannel', function () {
 
   describe('error deduplication', function () {
     it('should report a next(err) error once, on the origin layer, across mounted routers', function (done) {
-      const outer = new Router()
+      const { router: outer, server } = traced()
       const nested = new Router()
-      const server = createServer(outer)
-
-      dc.tracingChannel(CHANNEL).subscribe(handlers)
 
       nested.get('/bar', function innerHandler (req, res, next) {
         next(new Error('boom'))
       })
       outer.use('/foo', nested)
-      outer.use(function recover (err, req, res, next) { // eslint-disable-line no-unused-vars
-        res.statusCode = 500
-        res.end(err.message)
-      })
+      outer.use(recover)
 
       request(server)
         .get('/foo/bar')
         .expect(500, 'boom', function (err) {
           if (err) return done(err)
 
-          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          const errorEvents = events.filter(byPhase('error'))
           assert.equal(errorEvents.length, 1,
             'the same error bubbling through the mounted router must be reported once')
           assert.equal(errorEvents[0].ctx.layer.name, 'innerHandler',
@@ -806,29 +742,23 @@ describeTracing('TracingChannel', function () {
     })
 
     it('should report a next(err) error once across two mount levels', function (done) {
-      const outer = new Router()
+      const { router: outer, server } = traced()
       const mid = new Router()
       const deep = new Router()
-      const server = createServer(outer)
-
-      dc.tracingChannel(CHANNEL).subscribe(handlers)
 
       deep.get('/baz', function deepHandler (req, res, next) {
         next(new Error('boom'))
       })
       mid.use('/bar', deep)
       outer.use('/foo', mid)
-      outer.use(function recover (err, req, res, next) { // eslint-disable-line no-unused-vars
-        res.statusCode = 500
-        res.end(err.message)
-      })
+      outer.use(recover)
 
       request(server)
         .get('/foo/bar/baz')
         .expect(500, 'boom', function (err) {
           if (err) return done(err)
 
-          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          const errorEvents = events.filter(byPhase('error'))
           assert.equal(errorEvents.length, 1,
             'the error must not be re-reported at each ancestor router')
           assert.equal(errorEvents[0].ctx.layer.name, 'deepHandler')
@@ -838,27 +768,21 @@ describeTracing('TracingChannel', function () {
     })
 
     it('should report a thrown error once across mounted routers', function (done) {
-      const outer = new Router()
+      const { router: outer, server } = traced()
       const nested = new Router()
-      const server = createServer(outer)
-
-      dc.tracingChannel(CHANNEL).subscribe(handlers)
 
       nested.get('/bar', function innerThrow (req, res) {
         throw new Error('boom')
       })
       outer.use('/foo', nested)
-      outer.use(function recover (err, req, res, next) { // eslint-disable-line no-unused-vars
-        res.statusCode = 500
-        res.end(err.message)
-      })
+      outer.use(recover)
 
       request(server)
         .get('/foo/bar')
         .expect(500, 'boom', function (err) {
           if (err) return done(err)
 
-          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          const errorEvents = events.filter(byPhase('error'))
           assert.equal(errorEvents.length, 1,
             'a thrown error must be reported once, at its origin')
           assert.equal(errorEvents[0].ctx.layer.name, 'innerThrow')
@@ -868,27 +792,21 @@ describeTracing('TracingChannel', function () {
     })
 
     it('should report a rejected error once across mounted routers', function (done) {
-      const outer = new Router()
+      const { router: outer, server } = traced()
       const nested = new Router()
-      const server = createServer(outer)
-
-      dc.tracingChannel(CHANNEL).subscribe(handlers)
 
       nested.get('/bar', async function innerReject (req, res) {
         throw new Error('boom')
       })
       outer.use('/foo', nested)
-      outer.use(function recover (err, req, res, next) { // eslint-disable-line no-unused-vars
-        res.statusCode = 500
-        res.end(err.message)
-      })
+      outer.use(recover)
 
       request(server)
         .get('/foo/bar')
         .expect(500, 'boom', function (err) {
           if (err) return done(err)
 
-          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          const errorEvents = events.filter(byPhase('error'))
           assert.equal(errorEvents.length, 1,
             'a rejected error must be reported once, at its origin')
           assert.equal(errorEvents[0].ctx.layer.name, 'innerReject')
@@ -898,10 +816,7 @@ describeTracing('TracingChannel', function () {
     })
 
     it('should report next(err) once when an error handler forwards it', function (done) {
-      const router = new Router()
-      const server = createServer(router)
-
-      dc.tracingChannel(CHANNEL).subscribe(handlers)
+      const { router, server } = traced()
 
       router.get('/fail', function origin (req, res, next) {
         next(new Error('boom'))
@@ -909,17 +824,14 @@ describeTracing('TracingChannel', function () {
       router.use(function forwarding (err, req, res, next) {
         next(err)
       })
-      router.use(function recover (err, req, res, next) { // eslint-disable-line no-unused-vars
-        res.statusCode = 500
-        res.end(err.message)
-      })
+      router.use(recover)
 
       request(server)
         .get('/fail')
         .expect(500, 'boom', function (err) {
           if (err) return done(err)
 
-          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          const errorEvents = events.filter(byPhase('error'))
           assert.equal(errorEvents.length, 1,
             'forwarding the same error with next(err) must not re-report it')
           assert.equal(errorEvents[0].ctx.layer.name, 'origin')
@@ -929,10 +841,7 @@ describeTracing('TracingChannel', function () {
     })
 
     it('should report next(err) once when an error handler rethrows it', function (done) {
-      const router = new Router()
-      const server = createServer(router)
-
-      dc.tracingChannel(CHANNEL).subscribe(handlers)
+      const { router, server } = traced()
 
       router.get('/fail', function origin (req, res, next) {
         next(new Error('boom'))
@@ -940,17 +849,14 @@ describeTracing('TracingChannel', function () {
       router.use(function rethrowing (err, req, res, next) { // eslint-disable-line no-unused-vars
         throw err
       })
-      router.use(function recover (err, req, res, next) { // eslint-disable-line no-unused-vars
-        res.statusCode = 500
-        res.end(err.message)
-      })
+      router.use(recover)
 
       request(server)
         .get('/fail')
         .expect(500, 'boom', function (err) {
           if (err) return done(err)
 
-          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          const errorEvents = events.filter(byPhase('error'))
           assert.equal(errorEvents.length, 1,
             'throw err and next(err) are equivalent to the router, so rethrowing the same error must not re-report it')
           assert.equal(errorEvents[0].ctx.layer.name, 'origin')
@@ -962,10 +868,7 @@ describeTracing('TracingChannel', function () {
 
   describe('event ordering', function () {
     it('should emit start before asyncEnd', function (done) {
-      const router = new Router()
-      const server = createServer(router)
-
-      dc.tracingChannel(CHANNEL).subscribe(handlers)
+      const { router, server } = traced()
 
       router.get('/order', function (req, res) {
         res.statusCode = 200
@@ -992,10 +895,7 @@ describeTracing('TracingChannel', function () {
 
   describe('multiple middleware', function () {
     it('should emit events for each middleware in the chain', function (done) {
-      const router = new Router()
-      const server = createServer(router)
-
-      dc.tracingChannel(CHANNEL).subscribe(handlers)
+      const { router, server } = traced()
 
       router.use(function first (req, res, next) {
         next()
@@ -1015,7 +915,7 @@ describeTracing('TracingChannel', function () {
         .expect(200, function (err) {
           if (err) return done(err)
 
-          const startEvents = events.filter(function (e) { return e.phase === 'start' })
+          const startEvents = events.filter(byPhase('start'))
           const names = startEvents.map(function (e) { return e.ctx.layer.name })
 
           assert.ok(names.indexOf('first') >= 0, 'should trace first middleware')
@@ -1030,4 +930,15 @@ describeTracing('TracingChannel', function () {
 // Predicate matching a captured event by its layer name.
 function byLayer (name) {
   return function (e) { return e.ctx.layer && e.ctx.layer.name === name }
+}
+
+// Predicate matching a captured event by its lifecycle phase.
+function byPhase (name) {
+  return function (e) { return e.phase === name }
+}
+
+// Error handler that recovers by ending the response with the error message.
+function recover (err, req, res, next) { // eslint-disable-line no-unused-vars
+  res.statusCode = 500
+  res.end(err.message)
 }

--- a/test/tracing.js
+++ b/test/tracing.js
@@ -222,7 +222,7 @@ describeTracing('TracingChannel', function () {
           assert.ok(failingError, 'origin layer should emit error for next(err)')
           assert.equal(failingError.ctx.error.message, 'boom')
           assert.ok(!failingError.ctx.handled,
-            'origin layer ctx is not the handler — should not be marked handled')
+            'origin layer ctx is not the handler, so it should not be marked handled')
 
           done()
         })
@@ -257,11 +257,11 @@ describeTracing('TracingChannel', function () {
 
           const failingError = failingEvents.find(function (e) { return e.phase === 'error' })
           assert.ok(failingError,
-            'originating layer should emit error — unhandled-at-origin is always observable')
+            'originating layer should emit error, since unhandled-at-origin is always observable')
           assert.equal(failingError.ctx.error.message, 'boom')
 
           assert.ok(!errorHandlerEvents.some(function (e) { return e.phase === 'error' }),
-            'recovering error handler itself did not throw — should not emit error')
+            'recovering error handler itself did not throw, so it should not emit error')
 
           const errorHandlerStart = errorHandlerEvents.find(function (e) { return e.phase === 'start' })
           assert.equal(errorHandlerStart.ctx.handled, true,
@@ -269,7 +269,7 @@ describeTracing('TracingChannel', function () {
 
           const errorEvents = events.filter(function (e) { return e.phase === 'error' })
           assert.equal(errorEvents.length, 1,
-            'exactly one error event fires — on the origin layer that called next(err)')
+            'exactly one error event fires, on the origin layer that called next(err)')
 
           done()
         })
@@ -318,13 +318,13 @@ describeTracing('TracingChannel', function () {
           assert.ok(errorHandlerStart < errorHandlerEnd,
             'error handler start should come before its own end')
           assert.ok(errorHandlerEnd < failingEnd,
-            'error handler end should come before failing layer end — nesting contract: the error handler that runs via next(err) is nested inside the layer that triggered it, letting APMs attribute the error to the correct parent span')
+            'error handler end should come before failing layer end. Nesting contract: the error handler that runs via next(err) is nested inside the layer that triggered it, letting APMs attribute the error to the correct parent span')
 
           done()
         })
     })
 
-    it('should not emit error for next("route") control-flow sentinel', function (done) {
+    it('should not emit error for next("route") routing signal', function (done) {
       const router = new Router()
       const server = createServer(router)
 
@@ -346,13 +346,13 @@ describeTracing('TracingChannel', function () {
 
           const errorEvents = events.filter(function (e) { return e.phase === 'error' })
           assert.equal(errorEvents.length, 0,
-            'next("route") is a control-flow sentinel, not an error — nothing should publish')
+            'next("route") is a routing signal, not an error, so nothing should publish')
 
           done()
         })
     })
 
-    it('should not emit error for next("router") control-flow sentinel', function (done) {
+    it('should not emit error for next("router") routing signal', function (done) {
       const router = new Router()
       const server = createServer(router)
 
@@ -374,7 +374,63 @@ describeTracing('TracingChannel', function () {
 
           const errorEvents = events.filter(function (e) { return e.phase === 'error' })
           assert.equal(errorEvents.length, 0,
-            'next("router") is a control-flow sentinel, not an error — nothing should publish')
+            'next("router") is a routing signal, not an error, so nothing should publish')
+
+          done()
+        })
+    })
+
+    it('should not emit error when a handler throws the "route" routing signal', function (done) {
+      const router = new Router()
+      const server = createServer(router)
+
+      dc.tracingChannel('express.router.request').subscribe(handlers)
+
+      router.get('/skip', function throwRoute (req, res) {
+        throw 'route' // eslint-disable-line no-throw-literal
+      })
+
+      router.get('/skip', function nextRouteHandler (req, res) {
+        res.statusCode = 200
+        res.end('skipped')
+      })
+
+      request(server)
+        .get('/skip')
+        .expect(200, 'skipped', function (err) {
+          if (err) return done(err)
+
+          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          assert.equal(errorEvents.length, 0,
+            'a thrown "route" routing signal is not an error, so nothing should publish')
+
+          done()
+        })
+    })
+
+    it('should not emit error when a handler throws the "router" routing signal', function (done) {
+      const router = new Router()
+      const server = createServer(router)
+
+      dc.tracingChannel('express.router.request').subscribe(handlers)
+
+      router.use(function throwRouter (req, res) {
+        throw 'router' // eslint-disable-line no-throw-literal
+      })
+
+      router.get('/foo', function shouldNotRun (req, res) {
+        res.statusCode = 200
+        res.end('should not reach')
+      })
+
+      request(server)
+        .get('/foo')
+        .expect(404, function (err) {
+          if (err) return done(err)
+
+          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          assert.equal(errorEvents.length, 0,
+            'a thrown "router" routing signal is not an error, so nothing should publish')
 
           done()
         })
@@ -406,7 +462,7 @@ describeTracing('TracingChannel', function () {
 
           const errorEvents = events.filter(function (e) { return e.phase === 'error' })
           assert.equal(errorEvents.length, 1,
-            'exactly one error event fires — on the origin layer that called next(err)')
+            'exactly one error event fires, on the origin layer that called next(err)')
 
           done()
         })
@@ -556,7 +612,7 @@ describeTracing('TracingChannel', function () {
           const routeError = byName('throwingHandler')
           assert.ok(routeError, 'route layer should emit error')
           assert.ok(!routeError.ctx.handled,
-            'route layer is not an error handler — handled flag must be absent')
+            'route layer is not an error handler, so handled flag must be absent')
 
           const handlerError = byName('throwingErrorHandler')
           assert.ok(handlerError, 'error handler should emit its own error')
@@ -597,7 +653,7 @@ describeTracing('TracingChannel', function () {
           const routeError = byName('rejectingHandler')
           assert.ok(routeError, 'route layer should emit error')
           assert.ok(!routeError.ctx.handled,
-            'route layer is not an error handler — handled flag must be absent')
+            'route layer is not an error handler, so handled flag must be absent')
 
           const handlerError = byName('throwingErrorHandler')
           assert.ok(handlerError, 'error handler should emit its own error')

--- a/test/tracing.js
+++ b/test/tracing.js
@@ -180,39 +180,7 @@ describeTracing('TracingChannel', function () {
   })
 
   describe('error handler tracing', function () {
-    it('should trace error handlers (fn.length === 4)', function (done) {
-      const router = new Router()
-      const server = createServer(router)
-
-      dc.tracingChannel('express:request').subscribe(handlers)
-
-      router.get('/fail', function (req, res, next) {
-        next(new Error('boom'))
-      })
-
-      router.use(function myErrorHandler (err, req, res, next) { // eslint-disable-line no-unused-vars
-        res.statusCode = 500
-        res.end(err.message)
-      })
-
-      request(server)
-        .get('/fail')
-        .expect(500, 'boom', function (err) {
-          if (err) return done(err)
-
-          const startEvents = events.filter(function (e) { return e.phase === 'start' })
-          const errorHandlerStart = startEvents.find(function (e) {
-            return e.ctx.layer && e.ctx.layer.name === 'myErrorHandler'
-          })
-
-          assert.ok(errorHandlerStart, 'should have start event for error handler')
-          assert.equal(errorHandlerStart.ctx.layer.handle.length, 4)
-
-          done()
-        })
-    })
-
-    it('should not emit error on the originating layer when next(err) is recovered downstream', function (done) {
+    it('should trace error handlers (fn.length === 4) and mark their ctx as handled', function (done) {
       const router = new Router()
       const server = createServer(router)
 
@@ -239,19 +207,69 @@ describeTracing('TracingChannel', function () {
           const failingEvents = events.filter(byLayer('failingHandler'))
           const errorHandlerEvents = events.filter(byLayer('myErrorHandler'))
 
-          assert.ok(failingEvents.some(function (e) { return e.phase === 'start' }),
-            'originating layer should have a start event')
-          assert.ok(!failingEvents.some(function (e) { return e.phase === 'error' }),
-            'originating layer should not emit error — next(err) is normal control flow, not an exception')
+          const errorHandlerStart = errorHandlerEvents.find(function (e) { return e.phase === 'start' })
+          assert.ok(errorHandlerStart, 'should have start event for error handler')
+          assert.equal(errorHandlerStart.ctx.layer.handle.length, 4)
+          assert.equal(errorHandlerStart.ctx.handled, true,
+            'error handler ctx should be marked handled so APMs can dedup the origin error')
+          assert.ok(errorHandlerStart.ctx.error,
+            'error handler ctx should expose the error it received')
 
-          assert.ok(errorHandlerEvents.some(function (e) { return e.phase === 'start' }),
-            'recovering error handler should have a start event')
           assert.ok(!errorHandlerEvents.some(function (e) { return e.phase === 'error' }),
-            'recovering error handler should not emit error — it handled the error successfully')
+            'error handler itself did not throw, so it should not emit error')
+
+          const failingError = failingEvents.find(function (e) { return e.phase === 'error' })
+          assert.ok(failingError, 'origin layer should emit error for next(err)')
+          assert.equal(failingError.ctx.error.message, 'boom')
+          assert.ok(!failingError.ctx.handled,
+            'origin layer ctx is not the handler — should not be marked handled')
+
+          done()
+        })
+    })
+
+    it('should emit error on originating layer when next(err) is recovered downstream', function (done) {
+      const router = new Router()
+      const server = createServer(router)
+
+      dc.tracingChannel('express:request').subscribe(handlers)
+
+      router.get('/fail', function failingHandler (req, res, next) {
+        next(new Error('boom'))
+      })
+
+      router.use(function myErrorHandler (err, req, res, next) { // eslint-disable-line no-unused-vars
+        res.statusCode = 500
+        res.end(err.message)
+      })
+
+      request(server)
+        .get('/fail')
+        .expect(500, 'boom', function (err) {
+          if (err) return done(err)
+
+          const byLayer = function (name) {
+            return function (e) { return e.ctx.layer && e.ctx.layer.name === name }
+          }
+
+          const failingEvents = events.filter(byLayer('failingHandler'))
+          const errorHandlerEvents = events.filter(byLayer('myErrorHandler'))
+
+          const failingError = failingEvents.find(function (e) { return e.phase === 'error' })
+          assert.ok(failingError,
+            'originating layer should emit error — unhandled-at-origin is always observable')
+          assert.equal(failingError.ctx.error.message, 'boom')
+
+          assert.ok(!errorHandlerEvents.some(function (e) { return e.phase === 'error' }),
+            'recovering error handler itself did not throw — should not emit error')
+
+          const errorHandlerStart = errorHandlerEvents.find(function (e) { return e.phase === 'start' })
+          assert.equal(errorHandlerStart.ctx.handled, true,
+            'error handler ctx is marked handled so APMs can dedup against the origin error')
 
           const errorEvents = events.filter(function (e) { return e.phase === 'error' })
-          assert.equal(errorEvents.length, 0,
-            'no error event should fire anywhere when an error is forwarded via next() and recovered downstream')
+          assert.equal(errorEvents.length, 1,
+            'exactly one error event fires — on the origin layer that called next(err)')
 
           done()
         })
@@ -306,7 +324,7 @@ describeTracing('TracingChannel', function () {
         })
     })
 
-    it('should not emit error on the originating layer when next(err) is unhandled', function (done) {
+    it('should emit error on originating layer when next(err) is unhandled', function (done) {
       const router = new Router()
       const server = createServer(router)
 
@@ -325,14 +343,14 @@ describeTracing('TracingChannel', function () {
             return e.ctx.layer && e.ctx.layer.name === 'failingHandler'
           })
 
-          assert.ok(failingEvents.some(function (e) { return e.phase === 'start' }),
-            'originating layer should have a start event')
-          assert.ok(!failingEvents.some(function (e) { return e.phase === 'error' }),
-            'originating layer should not emit error even when no error handler exists — next(err) is not an exception from tracePromise\'s perspective')
+          const failingError = failingEvents.find(function (e) { return e.phase === 'error' })
+          assert.ok(failingError,
+            'unhandled next(err) must be observable on the origin layer')
+          assert.equal(failingError.ctx.error.message, 'unhandled boom')
 
           const errorEvents = events.filter(function (e) { return e.phase === 'error' })
-          assert.equal(errorEvents.length, 0,
-            'no error event fires on the channel when errors are forwarded via next(); APMs relying on this channel cannot detect next(err) errors')
+          assert.equal(errorEvents.length, 1,
+            'exactly one error event fires — on the origin layer that called next(err)')
 
           done()
         })

--- a/test/tracing.js
+++ b/test/tracing.js
@@ -6,6 +6,8 @@ const assert = utils.assert
 const createServer = utils.createServer
 const request = utils.request
 
+const CHANNEL = 'express.router.request'
+
 let dc
 let tracingChannel
 
@@ -34,7 +36,7 @@ describeTracing('TracingChannel', function () {
   })
 
   afterEach(function () {
-    dc.tracingChannel('express.router.request').unsubscribe(handlers)
+    dc.tracingChannel(CHANNEL).unsubscribe(handlers)
   })
 
   describe('when no subscribers', function () {
@@ -58,7 +60,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express.router.request').subscribe(handlers)
+      dc.tracingChannel(CHANNEL).subscribe(handlers)
 
       router.use(function myMiddleware (req, res, next) {
         next()
@@ -93,7 +95,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express.router.request').subscribe(handlers)
+      dc.tracingChannel(CHANNEL).subscribe(handlers)
 
       router.use(function (req, res, next) {
         next()
@@ -126,7 +128,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express.router.request').subscribe(handlers)
+      dc.tracingChannel(CHANNEL).subscribe(handlers)
 
       router.get('/users/:id', function getUser (req, res) {
         res.statusCode = 200
@@ -155,7 +157,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express.router.request').subscribe(handlers)
+      dc.tracingChannel(CHANNEL).subscribe(handlers)
 
       router.get('/foo', function myHandler (req, res) {
         res.statusCode = 200
@@ -184,7 +186,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express.router.request').subscribe(handlers)
+      dc.tracingChannel(CHANNEL).subscribe(handlers)
 
       router.get('/fail', function failingHandler (req, res, next) {
         next(new Error('boom'))
@@ -199,10 +201,6 @@ describeTracing('TracingChannel', function () {
         .get('/fail')
         .expect(500, 'boom', function (err) {
           if (err) return done(err)
-
-          const byLayer = function (name) {
-            return function (e) { return e.ctx.layer && e.ctx.layer.name === name }
-          }
 
           const failingEvents = events.filter(byLayer('failingHandler'))
           const errorHandlerEvents = events.filter(byLayer('myErrorHandler'))
@@ -232,7 +230,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express.router.request').subscribe(handlers)
+      dc.tracingChannel(CHANNEL).subscribe(handlers)
 
       router.get('/fail', function failingHandler (req, res, next) {
         next(new Error('boom'))
@@ -247,10 +245,6 @@ describeTracing('TracingChannel', function () {
         .get('/fail')
         .expect(500, 'boom', function (err) {
           if (err) return done(err)
-
-          const byLayer = function (name) {
-            return function (e) { return e.ctx.layer && e.ctx.layer.name === name }
-          }
 
           const failingEvents = events.filter(byLayer('failingHandler'))
           const errorHandlerEvents = events.filter(byLayer('myErrorHandler'))
@@ -279,7 +273,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express.router.request').subscribe(handlers)
+      dc.tracingChannel(CHANNEL).subscribe(handlers)
 
       router.use(function firstMiddleware (req, res, next) {
         next()
@@ -328,7 +322,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express.router.request').subscribe(handlers)
+      dc.tracingChannel(CHANNEL).subscribe(handlers)
 
       router.get('/skip', function skipToNextRoute (req, res, next) {
         next('route')
@@ -356,7 +350,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express.router.request').subscribe(handlers)
+      dc.tracingChannel(CHANNEL).subscribe(handlers)
 
       router.use(function ejectFromRouter (req, res, next) {
         next('router')
@@ -384,7 +378,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express.router.request').subscribe(handlers)
+      dc.tracingChannel(CHANNEL).subscribe(handlers)
 
       router.get('/skip', function throwRoute (req, res) {
         throw 'route' // eslint-disable-line no-throw-literal
@@ -412,7 +406,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express.router.request').subscribe(handlers)
+      dc.tracingChannel(CHANNEL).subscribe(handlers)
 
       router.use(function throwRouter (req, res) {
         throw 'router' // eslint-disable-line no-throw-literal
@@ -440,7 +434,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express.router.request').subscribe(handlers)
+      dc.tracingChannel(CHANNEL).subscribe(handlers)
 
       router.get('/fail', function failingHandler (req, res, next) {
         next(new Error('unhandled boom'))
@@ -474,7 +468,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express.router.request').subscribe(handlers)
+      dc.tracingChannel(CHANNEL).subscribe(handlers)
 
       router.get('/throw', function (req, res) {
         throw new Error('sync boom')
@@ -501,7 +495,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express.router.request').subscribe(handlers)
+      dc.tracingChannel(CHANNEL).subscribe(handlers)
 
       router.get('/reject', async function (req, res) {
         throw new Error('async boom')
@@ -528,7 +522,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express.router.request').subscribe(handlers)
+      dc.tracingChannel(CHANNEL).subscribe(handlers)
 
       router.get('/reject', async function rejectFalsy (req, res) {
         return Promise.reject() // eslint-disable-line prefer-promise-reject-errors
@@ -555,7 +549,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express.router.request').subscribe(handlers)
+      dc.tracingChannel(CHANNEL).subscribe(handlers)
 
       router.get('/throw', function throwingHandler (req, res) {
         throw new Error('sync boom')
@@ -584,7 +578,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express.router.request').subscribe(handlers)
+      dc.tracingChannel(CHANNEL).subscribe(handlers)
 
       router.get('/reject', async function rejectingHandler (req, res) {
         throw new Error('async boom')
@@ -613,7 +607,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express.router.request').subscribe(handlers)
+      dc.tracingChannel(CHANNEL).subscribe(handlers)
 
       router.get('/throw', function throwingHandler (req, res) {
         throw new Error('sync boom')
@@ -630,18 +624,15 @@ describeTracing('TracingChannel', function () {
           if (err) return done(err)
 
           const errorEvents = events.filter(function (e) { return e.phase === 'error' })
-          const byName = function (name) {
-            return errorEvents.find(function (e) { return e.ctx.layer.name === name })
-          }
 
           assert.equal(errorEvents.length, 2, 'error should fire on both layers')
 
-          const routeError = byName('throwingHandler')
+          const routeError = errorEvents.find(byLayer('throwingHandler'))
           assert.ok(routeError, 'route layer should emit error')
           assert.ok(!routeError.ctx.handled,
             'route layer is not an error handler, so handled flag must be absent')
 
-          const handlerError = byName('throwingErrorHandler')
+          const handlerError = errorEvents.find(byLayer('throwingErrorHandler'))
           assert.ok(handlerError, 'error handler should emit its own error')
           assert.equal(handlerError.ctx.handled, true,
             'error handler\'s own error event must carry handled:true so APMs can classify the span correctly')
@@ -654,7 +645,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express.router.request').subscribe(handlers)
+      dc.tracingChannel(CHANNEL).subscribe(handlers)
 
       router.get('/reject', async function rejectingHandler (req, res) {
         throw new Error('async boom')
@@ -671,18 +662,15 @@ describeTracing('TracingChannel', function () {
           if (err) return done(err)
 
           const errorEvents = events.filter(function (e) { return e.phase === 'error' })
-          const byName = function (name) {
-            return errorEvents.find(function (e) { return e.ctx.layer.name === name })
-          }
 
           assert.equal(errorEvents.length, 2, 'error should fire on both layers')
 
-          const routeError = byName('rejectingHandler')
+          const routeError = errorEvents.find(byLayer('rejectingHandler'))
           assert.ok(routeError, 'route layer should emit error')
           assert.ok(!routeError.ctx.handled,
             'route layer is not an error handler, so handled flag must be absent')
 
-          const handlerError = byName('throwingErrorHandler')
+          const handlerError = errorEvents.find(byLayer('throwingErrorHandler'))
           assert.ok(handlerError, 'error handler should emit its own error')
           assert.equal(handlerError.ctx.handled, true,
             'error handler\'s own error event must carry handled:true so APMs can classify the span correctly')
@@ -697,7 +685,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express.router.request').subscribe(handlers)
+      dc.tracingChannel(CHANNEL).subscribe(handlers)
 
       router.get('/async', function asyncHandler (req, res) {
         return new Promise(function (resolve) {
@@ -731,7 +719,7 @@ describeTracing('TracingChannel', function () {
       const nested = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express.router.request').subscribe(handlers)
+      dc.tracingChannel(CHANNEL).subscribe(handlers)
 
       nested.get('/bar', function nestedHandler (req, res) {
         res.statusCode = 200
@@ -763,7 +751,7 @@ describeTracing('TracingChannel', function () {
       const nested = new Router()
       const server = createServer(outer)
 
-      dc.tracingChannel('express.router.request').subscribe(handlers)
+      dc.tracingChannel(CHANNEL).subscribe(handlers)
 
       nested.get('/bar', function innerHandler (req, res, next) {
         next(new Error('boom'))
@@ -795,7 +783,7 @@ describeTracing('TracingChannel', function () {
       const deep = new Router()
       const server = createServer(outer)
 
-      dc.tracingChannel('express.router.request').subscribe(handlers)
+      dc.tracingChannel(CHANNEL).subscribe(handlers)
 
       deep.get('/baz', function deepHandler (req, res, next) {
         next(new Error('boom'))
@@ -826,7 +814,7 @@ describeTracing('TracingChannel', function () {
       const nested = new Router()
       const server = createServer(outer)
 
-      dc.tracingChannel('express.router.request').subscribe(handlers)
+      dc.tracingChannel(CHANNEL).subscribe(handlers)
 
       nested.get('/bar', function innerThrow (req, res) {
         throw new Error('boom')
@@ -856,7 +844,7 @@ describeTracing('TracingChannel', function () {
       const nested = new Router()
       const server = createServer(outer)
 
-      dc.tracingChannel('express.router.request').subscribe(handlers)
+      dc.tracingChannel(CHANNEL).subscribe(handlers)
 
       nested.get('/bar', async function innerReject (req, res) {
         throw new Error('boom')
@@ -885,7 +873,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express.router.request').subscribe(handlers)
+      dc.tracingChannel(CHANNEL).subscribe(handlers)
 
       router.get('/fail', function origin (req, res, next) {
         next(new Error('boom'))
@@ -918,7 +906,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express.router.request').subscribe(handlers)
+      dc.tracingChannel(CHANNEL).subscribe(handlers)
 
       router.get('/order', function (req, res) {
         res.statusCode = 200
@@ -948,7 +936,7 @@ describeTracing('TracingChannel', function () {
       const router = new Router()
       const server = createServer(router)
 
-      dc.tracingChannel('express.router.request').subscribe(handlers)
+      dc.tracingChannel(CHANNEL).subscribe(handlers)
 
       router.use(function first (req, res, next) {
         next()
@@ -979,3 +967,8 @@ describeTracing('TracingChannel', function () {
     })
   })
 })
+
+// Predicate matching a captured event by its layer name.
+function byLayer (name) {
+  return function (e) { return e.ctx.layer && e.ctx.layer.name === name }
+}

--- a/test/tracing.js
+++ b/test/tracing.js
@@ -674,6 +674,162 @@ describeTracing('TracingChannel', function () {
     })
   })
 
+  describe('error deduplication', function () {
+    it('should report a next(err) error once, on the origin layer, across mounted routers', function (done) {
+      const outer = new Router()
+      const nested = new Router()
+      const server = createServer(outer)
+
+      dc.tracingChannel('express.router.request').subscribe(handlers)
+
+      nested.get('/bar', function innerHandler (req, res, next) {
+        next(new Error('boom'))
+      })
+      outer.use('/foo', nested)
+      outer.use(function recover (err, req, res, next) { // eslint-disable-line no-unused-vars
+        res.statusCode = 500
+        res.end(err.message)
+      })
+
+      request(server)
+        .get('/foo/bar')
+        .expect(500, 'boom', function (err) {
+          if (err) return done(err)
+
+          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          assert.equal(errorEvents.length, 1,
+            'the same error bubbling through the mounted router must be reported once')
+          assert.equal(errorEvents[0].ctx.layer.name, 'innerHandler',
+            'the single error event belongs to the origin layer')
+
+          done()
+        })
+    })
+
+    it('should report a next(err) error once across two mount levels', function (done) {
+      const outer = new Router()
+      const mid = new Router()
+      const deep = new Router()
+      const server = createServer(outer)
+
+      dc.tracingChannel('express.router.request').subscribe(handlers)
+
+      deep.get('/baz', function deepHandler (req, res, next) {
+        next(new Error('boom'))
+      })
+      mid.use('/bar', deep)
+      outer.use('/foo', mid)
+      outer.use(function recover (err, req, res, next) { // eslint-disable-line no-unused-vars
+        res.statusCode = 500
+        res.end(err.message)
+      })
+
+      request(server)
+        .get('/foo/bar/baz')
+        .expect(500, 'boom', function (err) {
+          if (err) return done(err)
+
+          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          assert.equal(errorEvents.length, 1,
+            'the error must not be re-reported at each ancestor router')
+          assert.equal(errorEvents[0].ctx.layer.name, 'deepHandler')
+
+          done()
+        })
+    })
+
+    it('should report a thrown error once across mounted routers', function (done) {
+      const outer = new Router()
+      const nested = new Router()
+      const server = createServer(outer)
+
+      dc.tracingChannel('express.router.request').subscribe(handlers)
+
+      nested.get('/bar', function innerThrow (req, res) {
+        throw new Error('boom')
+      })
+      outer.use('/foo', nested)
+      outer.use(function recover (err, req, res, next) { // eslint-disable-line no-unused-vars
+        res.statusCode = 500
+        res.end(err.message)
+      })
+
+      request(server)
+        .get('/foo/bar')
+        .expect(500, 'boom', function (err) {
+          if (err) return done(err)
+
+          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          assert.equal(errorEvents.length, 1,
+            'a thrown error must be reported once, at its origin')
+          assert.equal(errorEvents[0].ctx.layer.name, 'innerThrow')
+
+          done()
+        })
+    })
+
+    it('should report a rejected error once across mounted routers', function (done) {
+      const outer = new Router()
+      const nested = new Router()
+      const server = createServer(outer)
+
+      dc.tracingChannel('express.router.request').subscribe(handlers)
+
+      nested.get('/bar', async function innerReject (req, res) {
+        throw new Error('boom')
+      })
+      outer.use('/foo', nested)
+      outer.use(function recover (err, req, res, next) { // eslint-disable-line no-unused-vars
+        res.statusCode = 500
+        res.end(err.message)
+      })
+
+      request(server)
+        .get('/foo/bar')
+        .expect(500, 'boom', function (err) {
+          if (err) return done(err)
+
+          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          assert.equal(errorEvents.length, 1,
+            'a rejected error must be reported once, at its origin')
+          assert.equal(errorEvents[0].ctx.layer.name, 'innerReject')
+
+          done()
+        })
+    })
+
+    it('should report next(err) once when an error handler forwards it', function (done) {
+      const router = new Router()
+      const server = createServer(router)
+
+      dc.tracingChannel('express.router.request').subscribe(handlers)
+
+      router.get('/fail', function origin (req, res, next) {
+        next(new Error('boom'))
+      })
+      router.use(function forwarding (err, req, res, next) {
+        next(err)
+      })
+      router.use(function recover (err, req, res, next) { // eslint-disable-line no-unused-vars
+        res.statusCode = 500
+        res.end(err.message)
+      })
+
+      request(server)
+        .get('/fail')
+        .expect(500, 'boom', function (err) {
+          if (err) return done(err)
+
+          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          assert.equal(errorEvents.length, 1,
+            'forwarding the same error with next(err) must not re-report it')
+          assert.equal(errorEvents[0].ctx.layer.name, 'origin')
+
+          done()
+        })
+    })
+  })
+
   describe('event ordering', function () {
     it('should emit start before asyncEnd', function (done) {
       const router = new Router()

--- a/test/tracing.js
+++ b/test/tracing.js
@@ -324,6 +324,34 @@ describeTracing('TracingChannel', function () {
         })
     })
 
+    it('should not emit error for next("route") or next("router") control-flow sentinels', function (done) {
+      const router = new Router()
+      const server = createServer(router)
+
+      dc.tracingChannel('express:request').subscribe(handlers)
+
+      router.get('/skip', function skipToNextRoute (req, res, next) {
+        next('route')
+      })
+
+      router.get('/skip', function nextRouteHandler (req, res) {
+        res.statusCode = 200
+        res.end('skipped')
+      })
+
+      request(server)
+        .get('/skip')
+        .expect(200, 'skipped', function (err) {
+          if (err) return done(err)
+
+          const errorEvents = events.filter(function (e) { return e.phase === 'error' })
+          assert.equal(errorEvents.length, 0,
+            'next("route") is a control-flow sentinel, not an error — nothing should publish')
+
+          done()
+        })
+    })
+
     it('should emit error on originating layer when next(err) is unhandled', function (done) {
       const router = new Router()
       const server = createServer(router)
@@ -480,7 +508,8 @@ describeTracing('TracingChannel', function () {
         throw new Error('sync boom')
       })
 
-      router.use(function throwingErrorHandler (err, req, res, next) { // eslint-disable-line no-unused-vars
+      // eslint-disable-next-line no-unused-vars, n/handle-callback-err
+      router.use(function throwingErrorHandler (err, req, res, next) {
         throw new Error('handler boom')
       })
 
@@ -510,7 +539,8 @@ describeTracing('TracingChannel', function () {
         throw new Error('async boom')
       })
 
-      router.use(function throwingErrorHandler (err, req, res, next) { // eslint-disable-line no-unused-vars
+      // eslint-disable-next-line no-unused-vars, n/handle-callback-err
+      router.use(function throwingErrorHandler (err, req, res, next) {
         throw new Error('handler boom')
       })
 


### PR DESCRIPTION
This PR adds a single [tracing channel](https://nodejs.org/api/diagnostics_channel.html#class-tracingchannel) that emits structured lifecycle events (start, end, asyncStart, asyncEnd, error) for every middleware, route handler, and error handler execution.

This builds on #96 but uses tracing channels instead which enables context propagation out of the box.

### Context shape

The context object is pretty minimal, providing both `req` and `res` enables APMs to figure out how to react to that specific payload.

```js
{ req, res, layer }
```

The `layer` is the Layer instance. Subscribers use `layer.name`, `layer.handle.length` (4 for error handlers), and `req.route` (set when inside a matched route) to classify and name spans however they see fit.

### Usage Example:

This is an example I've set up locally using a Sentry setup with this PR patched in:

```ts
const Sentry = require('@sentry/node')
// otel-tracing-channel is a simple tracing channel wrapper that patches in the OTEL context propagation
// atm otel doesn't support tracing channels, so this workaround is required for OTEL-based APMs
// the user wouldn't need this and typically they can set their own thing with ALS.
const { tracingChannel } = require('otel-tracing-channel')

Sentry.init({
  // ...
})

// Subscribe to express:request TracingChannel and create Sentry spans
const channel = tracingChannel('pillarjs.router.request', (ctx) => {
  const { layer, req } = ctx
  const isErrorHandler = layer.handle.length === 4
  const isRouteHandler = Boolean(req.route)

  const spanName = isRouteHandler
    ? `${req.method} ${req.route.path}`
    : isErrorHandler
      ? `error_handler - ${layer.name}`
      : `middleware - ${layer.name}`

  return Sentry.startSpanManual(
    {
      name: spanName,
      op: isRouteHandler ? 'http.handler' : isErrorHandler ? 'middleware.error' : 'middleware',
      attributes: {
        'express.name': layer.name,
        'http.request.method': req.method,
        'url.path': req.url,
        'url.full': req.originalUrl,
        ...(req.route && { 'http.route': req.route.path }),
        ...(req.query && Object.keys(req.query).length > 0 && {
          'url.query': JSON.stringify(req.query)
        }),
        ...(req.params && Object.keys(req.params).length > 0 && {
          'express.params': JSON.stringify(req.params)
        })
      }
    },
    (span) => span
  )
})

channel.subscribe({
  asyncEnd (ctx) {
    if (ctx.req.route) {
      ctx.span?.setAttribute('http.response.status_code', ctx.res.statusCode)
    }
    ctx.span?.end()
  },
  error (ctx) {
    ctx.span?.setStatus({ code: 2, message: ctx.error?.message })
    ctx.span?.end()
  }
})

// Express App
const express = require('express')
const app = express()

// Middleware
app.use(express.json())

app.use(function requestLogger (req, res, next) {
  console.log(`${req.method} ${req.url}`)
  next()
})

app.use(function addRequestId (req, res, next) {
  req.requestId = Math.random().toString(36).slice(2, 10)
  res.setHeader('x-request-id', req.requestId)
  next()
})

// Routes
app.get('/users/:id', function validateId (req, res, next) {
  if (isNaN(req.params.id)) {
    return res.status(400).json({ error: 'id must be a number' })
  }
  next()
}, function loadUser (req, res, next) {
  req.user = { id: req.params.id, name: 'Test User' }
  next()
}, function getUser (req, res) {
  res.json({ ...req.user, requestId: req.requestId })
})
```

This produces a waterfall view looking like this:

<img width="2706" height="1030" alt="CleanShot 2026-04-15 at 08 36 22@2x" src="https://github.com/user-attachments/assets/4ef085f7-39fe-48ef-bfad-17306ee4826c" />

Note: The three spans that look the same at the bottom actually represent the three handlers executing for that route, it is up to the subscriber to decide which one is the route handler and how to name the other ones since it has access to `layer`.

### Is tracing channels experimental?

We had this come up a few times during the initiative of pushing the adoption of dc across the ecosystem, most recently this was brought up and responded to by @Qard here:

https://github.com/Automattic/mongoose/issues/16105#issuecomment-4338019446

> Yes, it has mainly been left as experimental due to a lack of adoption, but also as a signal that we may make improvements as we learn from uses of it. That learning has largely already been absorbed and applied via recent PRs at this point. There are several improvements incoming, but none of those change the existing code, which will be left as-is, they add some additional systems to handle some more specific cases such as async iterators.

> The TracingChannel API will be left as-is, likely forever at this point as it is very important to us to retain compatibility essentially indefinitely, because APM vendors have many customers using old Node.js versions even well beyond the EOL of Node.js itself [...]

### Related work

- This builds on #96 but uses tracing channels
- Related to https://github.com/expressjs/express/pull/7041
- Does the same as https://github.com/expressjs/express/pull/7171 but uses tracing channels
- Closes https://github.com/expressjs/express/issues/6353

### Caveats

- The channel name right now is `pillarjs.router.request`, in the original PR it was `request` but I think channel names need to have a relationship with the module name otherwise we risk duplication in the ecosystem.
- Depending on the exact version of Node 18 certain behaviors are expected in this PR:
  - Node versions without `hasSubscribers` will assume that there is a subscriber and will execute the traced path (with context object allocation). Multiple libraries like `redis` and `mysql2` accepted this limitation.
  - Node versions without `tracingChannel` support will just not offer tracing of any kind. The fallback here is NOOP.
- It is up to APMs to represent the onion shape with nested handlers or flatten certain spans which is relatively easy if APMs have their own ALS context propagation strategy.
- Tests running a node version that do not have `tracingChannel` will be skipped via `describe.skip`.